### PR TITLE
Improve Commands class to fully handle data that is sent to Discord

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -1,7 +1,7 @@
 import datetime
 from collections import defaultdict
 from string import ascii_lowercase as alphabet
-from typing import List, Callable, Union
+from typing import List, Callable, Dict, Any
 
 import discord
 
@@ -19,7 +19,7 @@ class Commands:
     client: discord.Client = None
 
     @staticmethod
-    def get_command_by_name(command: str) -> Callable[[List[str]], str]:
+    def get_command_by_name(command: str) -> Callable[[List[str]], Dict[str, Any]]:
         """
         Backbone of the command interface. Entries should be formatted as: ::
 
@@ -27,7 +27,8 @@ class Commands:
 
         The function should be defined further down in this class as a static method.
         All functions must take in only a list of strings as their argument,
-        and return only a single string, or a discord.Embed object.
+        and return a dictionary which represents keyword argument pairs to be used by
+        channel.send()
 
         :return: A function that executes the requested command
         """
@@ -37,29 +38,30 @@ class Commands:
         })[command]
 
     @staticmethod
-    def help(args: List[str]) -> str:
+    def help(args: List[str]) -> Dict[str, str]:
         """
         Default command, lists all possible commands and a short description of each.
         :param args: Ignored
         :return: A formatted list of all commands
         """
-        return """Commands:
+        return {'content': """Commands:
         `!help`  - Runs this command
         `!hello` - Prints "Hello!"
         `!poll`  - Runs a simple poll
         """
+                }
 
     @staticmethod
-    def hello(args: List[str]) -> str:
+    def hello(args: List[str]) -> Dict[str, str]:
         """
         Prints "Hello!" on input "!hello"
         :param args: ignored
         :return: The string "Hello!"
         """
-        return "Hello!"
+        return {'content': "Hello!"}
 
     @staticmethod
-    def poll(args: List[str]) -> discord.Embed:
+    def poll(args: List[str]) -> Dict[str, discord.Embed]:
         question, *options = args
         embed = discord.Embed(
             title=':bar_chart: **New Poll!**',
@@ -85,16 +87,16 @@ class Commands:
 
         SideEffects.task = react
 
-        return embed
+        return {'embed': embed}
 
     @staticmethod
-    def execute(command: str, args: List[str], client: discord.Client = None) -> Union[str, discord.Embed]:
+    def execute(command: str, args: List[str], client: discord.Client = None) -> dict:
         """
         Executes the command with the given args
         :param command: The !command to execute
         :param args: The arguments for the command
         :param client: The Discord client being used (MemeBot)
-        :return: The result of running command with args
+        :return: The result of running command with args, formatted as a kwargs dictionary to be sent to Discord
         """
         if Commands.client is None:
             if client is None:

--- a/memebot.py
+++ b/memebot.py
@@ -34,8 +34,5 @@ class MemeBot(discord.Client):
         command, *args = shlex.split(message.content)
 
         if command.startswith('!'):
-            output = Commands.execute(command, args, self)
-            is_embed = type(output) is discord.Embed
-            new_message = await message.channel.send(output if not is_embed else None,
-                                                     embed=output if is_embed else None)
+            new_message = await message.channel.send(**Commands.execute(command, args, self))
             await SideEffects.borrow(new_message)


### PR DESCRIPTION
**Does this improvement fix a bug/issue? Please describe.**
N/A

**What do you dislike about the feature in its current state?**
The issue is that the `Command` class isn't set up to really handle more than text being returned. It should be able to send back data that can instantly be sent off to discord without further processing.

**Describe the solution you'd like**
Format all command functions to return a dictionary that specifies the data being sent as keyword arguments to the `send` command. This way, the dictionary can simply be used as `**data` when it is sent. This also allows the `Command` methods to return multiple pieces of data through one object.

**What tradeoffs are made by implementing your improvement?**
The functions in the `Command` class become a little more complicated, in that they have return a dictionary and specify what each item in the dictionary is.

**Describe alternatives you've considered**
The current solution of type checking everything that comes out of the `Command` class

**Additional context**
N/A