### PR TITLE
Create CommandOutput class so dicts/strings don't have to be hardcoded

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -1,7 +1,8 @@
 import datetime
+import io
 from collections import defaultdict
 from string import ascii_lowercase as alphabet
-from typing import List, Callable, Dict, Any
+from typing import List, Callable, Union, ValuesView, KeysView
 
 import discord
 
@@ -19,7 +20,7 @@ class Commands:
     client: discord.Client = None
 
     @staticmethod
-    def get_command_by_name(command: str) -> Callable[[List[str]], Dict[str, Any]]:
+    def get_command_by_name(command: str) -> Callable[[List[str]], 'CommandOutput']:
         """
         Backbone of the command interface. Entries should be formatted as: ::
 
@@ -38,30 +39,28 @@ class Commands:
         })[command]
 
     @staticmethod
-    def help(args: List[str]) -> Dict[str, str]:
+    def help(args: List[str]) -> 'CommandOutput':
         """
         Default command, lists all possible commands and a short description of each.
         :param args: Ignored
         :return: A formatted list of all commands
         """
-        return {'content': """Commands:
+        return CommandOutput().add_text("""Commands:
         `!help`  - Runs this command
         `!hello` - Prints "Hello!"
-        `!poll`  - Runs a simple poll
-        """
-                }
+        `!poll`  - Runs a simple poll""")
 
     @staticmethod
-    def hello(args: List[str]) -> Dict[str, str]:
+    def hello(args: List[str]) -> 'CommandOutput':
         """
         Prints "Hello!" on input "!hello"
         :param args: ignored
         :return: The string "Hello!"
         """
-        return {'content': "Hello!"}
+        return CommandOutput().add_text("Hello!")
 
     @staticmethod
-    def poll(args: List[str]) -> Dict[str, discord.Embed]:
+    def poll(args: List[str]) -> 'CommandOutput':
         question, *options = args
         embed = discord.Embed(
             title=':bar_chart: **New Poll!**',
@@ -87,16 +86,16 @@ class Commands:
 
         SideEffects.task = react
 
-        return {'embed': embed}
+        return CommandOutput().add_embed(embed)
 
     @staticmethod
-    def execute(command: str, args: List[str], client: discord.Client = None) -> dict:
+    def execute(command: str, args: List[str], client: discord.Client = None) -> 'CommandOutput':
         """
         Executes the command with the given args
         :param command: The !command to execute
         :param args: The arguments for the command
         :param client: The Discord client being used (MemeBot)
-        :return: The result of running command with args, formatted as a kwargs dictionary to be sent to Discord
+        :return: The result of running command with args, formatted as a CommandOutput object to be sent to Discord
         """
         if Commands.client is None:
             if client is None:
@@ -125,3 +124,121 @@ class SideEffects:
         if SideEffects.task is not None:
             await SideEffects.task(message)
         SideEffects.task = None
+
+
+class CommandOutput:
+    """
+    A class to standardize building a command output. Methods correspond to
+    kwargs in discord.message.message.channel.send()
+    """
+    CONTENT = 'content'
+    EMBED = 'embed'
+    TTS = 'tts'
+    FILE = 'file'
+    FILES = 'files'
+    LIFETIME = 'delete_after'
+    NONCE = 'nonce'
+
+    def __init__(self, kwargs: dict = None):
+        if type(kwargs) is dict:
+            self.kwargs = kwargs
+        else:
+            # dict to hold keyword arguments
+            self.kwargs = {}
+
+    def add_content(self, content: str) -> 'CommandOutput':
+        """
+        Adds content to a message being sent to discord. This can plainly be regarded as
+        a regular text message
+        :param content: The text to be added to the output
+        :return: self
+        """
+        self.kwargs[CommandOutput.CONTENT] = content
+        return self
+
+    def add_text(self, text: str) -> 'CommandOutput':
+        """
+        Wrapper method for add_content just in case the name isn't clear
+        :param text: The text to send
+        :return: self
+        """
+        return self.add_content(text)
+
+    def add_embed(self, embed: discord.Embed) -> 'CommandOutput':
+        """
+        Adds an embed to a message being sent to discord
+        :param embed: The embed object to add to the message
+        :return: self
+        """
+        self.kwargs[CommandOutput.EMBED] = embed
+        return self
+
+    def set_tts(self, tts: bool = True) -> 'CommandOutput':
+        """
+        Enables or disables text-to-speech for a message being sent to discord
+        :param tts: Tells if the content of this message will be read aloud (Default: True)
+        :return: self
+        """
+        self.kwargs[CommandOutput.TTS] = tts
+        return self
+
+    def add_file(self, file: Union[str, io.BufferedIOBase], file_name: str = None,
+                 spoiler: bool = False) -> 'CommandOutput':
+        """
+        Adds a file to a message that is being sent to discord
+        :param file: The file being sent. Can either be a path (string) or file-like object (io.BufferedIOBase)
+        :param file_name: An optional, alternate name to the file
+        :param spoiler: Tells whether or not the file should be spoiler'd (Default: False)
+        :return: self
+        """
+        self.kwargs[CommandOutput.FILE] = discord.File(fp=file, filename=file_name, spoiler=spoiler)
+        return self
+
+    def add_files(self, files: List[Union[str, io.BufferedIOBase]]) -> 'CommandOutput':
+        """
+        Adds multiple files at once to a message being sent to Discord. !! Maximum of 10 files !!
+        :param files: list of file paths or file-like objects
+        :return: self
+        :raises ValueError if there is an attempt to add more than 10 files to the output
+        """
+        # check if, after this operation, there will be more than 10 files in the message
+        total_files = (len(self.kwargs[CommandOutput.FILES]) if CommandOutput.FILES in self.kwargs else 0) + len(files)
+        if total_files > 10:
+            raise ValueError(f"Cannot send more than 10 files! (tried to send total of {total_files}")
+        # if there are no files stored in the output, initialize it in the kwargs dict
+        if total_files == len(files):
+            self.kwargs[CommandOutput.FILES] = []
+        self.kwargs[CommandOutput.FILES] += files
+        return self
+
+    def set_time_to_delete(self, time_to_delete: float) -> 'CommandOutput':
+        """
+        Wrapper for set_lifetime()
+        :param time_to_delete: The time (in seconds) after which this message will be deleted after sending
+        :return: self
+        """
+        return self.set_lifetime(time_to_delete)
+
+    def set_lifetime(self, lifetime: float) -> 'CommandOutput':
+        """
+        Sets the output to expire (be deleted) a certain time after being posted
+        :param lifetime: The expiration time of this message, in seconds
+        :return: self
+        """
+        self.kwargs[CommandOutput.LIFETIME] = lifetime
+        return self
+
+    def __str__(self) -> str:
+        return str(self.kwargs)
+
+    def __contains__(self, item: str) -> bool:
+        return item in self.kwargs
+
+    def __add__(self, other: 'CommandOutput') -> 'CommandOutput':
+        return CommandOutput(self.kwargs.update(other.kwargs))
+
+    def keys(self) -> KeysView[str]:
+        return self.kwargs.keys()
+
+    def values(self) -> ValuesView:
+        return self.kwargs.values()

--- a/memebot.py
+++ b/memebot.py
@@ -34,5 +34,5 @@ class MemeBot(discord.Client):
         command, *args = shlex.split(message.content)
 
         if command.startswith('!'):
-            new_message = await message.channel.send(**Commands.execute(command, args, self))
+            new_message = await message.channel.send(**Commands.execute(command, args, self).kwargs)
             await SideEffects.borrow(new_message)


### PR DESCRIPTION
My thought process here is that hardcoding strings multiple times makes my skin crawl, and it also makes programmers less reliant on the documentation to determine what data they're allowed to send in a discord message. If you like it, cool.