### PR TITLE
Role Moderation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,4 @@ Current commands that can be used in Discord:
     !help  - display help text
     !hello - print "Hello!"
     !poll  - create a simple poll
+    !role  - manage mentionable roles

--- a/commands.py
+++ b/commands.py
@@ -3,13 +3,13 @@ import io
 from collections import defaultdict
 from string import ascii_lowercase as alphabet
 from typing import List, Callable, Union, ValuesView, KeysView
+from threading import Lock
 
 import discord
 
 from lib import constants
 
 # TODO: replace message saving temp solution with something better
-from threading import Lock
 message_lock = Lock()
 
 # noinspection PyUnusedLocal

--- a/commands.py
+++ b/commands.py
@@ -2,8 +2,8 @@ import datetime
 import io
 from collections import defaultdict
 from string import ascii_lowercase as alphabet
-from typing import List, Callable, Union, ValuesView, KeysView
 from threading import Lock
+from typing import List, Callable, Union, ValuesView, KeysView
 
 import discord
 

--- a/commands.py
+++ b/commands.py
@@ -151,6 +151,7 @@ class Commands:
         for role in guild.roles:
             if role.name == target_name:
                 target_role = role
+                break
 
         # handle create
         if action == 'create':
@@ -226,7 +227,7 @@ class Commands:
 
                 return CommandOutput().add_text(members_string)
 
-
+        # send help message if invalid action 
         return help_message
         
 
@@ -237,6 +238,7 @@ class Commands:
         :param command: The !command to execute
         :param args: The arguments for the command
         :param client: The Discord client being used (MemeBot)
+        :param message: The Discord message which triggered the command execution
         :return: The result of running command with args, formatted as a CommandOutput object to be sent to Discord
         """
         if Commands.client is None:

--- a/main.py
+++ b/main.py
@@ -16,7 +16,8 @@ def main(argv: List[str]) -> int:
     # !! DO NOT HARDCODE THE TOKEN !!
     with open('client_token') as token_file:
         token = token_file.read()
-
+    
+    #print(token)
     return client.run(token)
 
 

--- a/main.py
+++ b/main.py
@@ -16,8 +16,7 @@ def main(argv: List[str]) -> int:
     # !! DO NOT HARDCODE THE TOKEN !!
     with open('client_token') as token_file:
         token = token_file.read()
-    
-    #print(token)
+
     return client.run(token)
 
 

--- a/memebot.py
+++ b/memebot.py
@@ -34,5 +34,6 @@ class MemeBot(discord.Client):
         command, *args = shlex.split(message.content)
 
         if command.startswith('!'):
-            new_message = await message.channel.send(**Commands.execute(command, args, self).kwargs)
+            result = await Commands.execute(command, args, self, message)
+            new_message = await message.channel.send(**result.kwargs)
             await SideEffects.borrow(new_message)


### PR DESCRIPTION
Resolves #5 

Subcommands `create`, `join`, `leave`, `delete`, `list`. `Delete` will only delete a memberless role. `List` will list members of a role. Users can join a role that they are already in and leave a role that they are already not in with no unerlying effect. 

Added temporary workaround to give all fucntions in `Commands` class access to the message object on which they are acting (`Commands.command_message`). This is protected by a global lock for now. 

Refactored some code to allow for `async` function calls within the `Commands` functions. This required making every `Commands` funciton `async` and adding a few `await` statements.