### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3.8.1-slim
+
+# pull in required files
+WORKDIR /home/memebot/
+COPY . .
+
+# set up virtual environment
+ENV VIRTUAL_ENV "/venv"
+RUN python -m venv $VIRTUAL_ENV
+ENV PATH "$VIRTUAL_ENV/bin:$PATH"
+
+# install dependencies
+RUN python -m pip install -r requirements.txt
+
+# run memebot
+CMD ["python3", "main.py"]

--- a/README.md
+++ b/README.md
@@ -16,3 +16,8 @@ Current commands that can be used in Discord:
     !hello - print "Hello!"
     !poll  - create a simple poll
     !role  - manage mentionable roles
+
+## Docker
+Memebot has a straightforward Docker image that can be build based on the [Dockerfile](./Dockerfile) in this 
+repository. This image can be used for both deployment and testing purposes, although regular testing with it is not 
+recommended, as the image has to be rebuilt any time a file is edited or a configuration is changed.

--- a/main.py
+++ b/main.py
@@ -15,7 +15,7 @@ def main(argv: List[str]) -> int:
 
     # !! DO NOT HARDCODE THE TOKEN !!
     with open('client_token') as token_file:
-        token = token_file.read()
+        token = token_file.read().strip()
 
     return client.run(token)
 


### PR DESCRIPTION
This PR adds the ability to deploy Memebot with Docker. A Dockerfile was added at the root of the repository, with some supplimentary information in the README. A line in [main.py](./main.py) was also amended to reflect an apparent change with file.read() in python 3.8, wherein a newline is placed at the end of the string, even if it doesn't exist in the file. This newline causes authentication to Discord to fail. Mitigating this is as simple as "stripping" the file of whitespace.

I would like at least one reviewer to test the Docker image on their machine. It is fairly straightforward:

1. Install Docker
2. cd into the repository root
3. Build the Docker image with `docker build -t memebot .`
4. Run the container with `docker run --rm -d --name memebot-test memebot`
5. Test the container out by running some commands in the bot testing server. It should work just the same as when you run it with your normal python environment.
6. Kill the container with `docker stop memebot-test`. It should delete itself after it is stopped.

Also, once this is merged, we can deploy Memebot :))))