### PR TITLE
Add role list command with no argument

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -189,8 +189,7 @@ class Commands:
             for role in guild.roles[:0:-1]:  # top-down, excluding @everyone
                 if can_manage:
                     roles.append(role.name)
-                    continue
-                if Commands.client.user in role.members:
+                elif Commands.client.user in role.members:
                     can_manage = True
             roles.insert(0, "Roles managed through `!role` command:")
             return CommandOutput().add_text("\n- ".join(roles))

--- a/commands.py
+++ b/commands.py
@@ -181,7 +181,7 @@ class Commands:
                 break
                     
         # handle list with no role name
-        if action == 'list' and target_role is None:
+        if action == 'list' and target_name == '':
             roles = []
             can_manage = False
             # Bot can manage all roles below its highest role. Find that role 


### PR DESCRIPTION
Using the command '!role list' with no role argument will list all the 
roles that can be managed by memebot.

The bot can manage all roles below its highest role in the hierarchy.