### PR TITLE
Replace curly quotes with straight quotes

### DIFF
--- a/memebot.py
+++ b/memebot.py
@@ -32,6 +32,9 @@ class MemeBot(discord.Client):
             # ignore messages sent by this bot (for now)
             return
 
+        # convert curly quotes to straight quotes
+        message.content = message.content.replace('“','"').replace('”','"')
+
         if self.is_command(message.content):
             try:
                 command, *args = shlex.split(message.content)


### PR DESCRIPTION
Our parsing did not recognize curly quotes as quotes, and would fail to parse
commands which used them. Replacing all curly quotes in the message with
straight quotes before parsing solves this problem.