### PR TITLE
Better handle malformed role commands

### DIFF
--- a/src/commands/commands.py
+++ b/src/commands/commands.py
@@ -187,7 +187,7 @@ class Commands:
             # Bot can manage all roles below its highest role. Find that role 
             # and begin listing roles from that point onward.
             for role in guild.roles[:0:-1]:  # top-down, excluding @everyone
-                if can_manage:
+                if can_manage and role.name != Commands.client.user.name:
                     roles.append(role.name)
                 elif Commands.client.user in role.members:
                     can_manage = True

--- a/src/commands/commands.py
+++ b/src/commands/commands.py
@@ -138,7 +138,7 @@ class Commands:
         )
         # ensure proper usage and get args
         args = list(map(str.lower, args))
-        aciton = ""
+        action = ""
         if len(args) == 2: 
             action, target_name = args
         elif len(args) == 1:

--- a/src/commands/commands.py
+++ b/src/commands/commands.py
@@ -227,7 +227,7 @@ class Commands:
         
         # ensure role provided and exists for remaining actions
         if target_role is None: 
-            if target_role == '':
+            if target_name == '':
                 msg = f'The role `@{target_name}` was not found!'
             else:
                 msg = 'No role provided.'

--- a/src/commands/commands.py
+++ b/src/commands/commands.py
@@ -190,7 +190,7 @@ class Commands:
             # Bot can manage all roles below its highest role. Find that role 
             # and begin listing roles from that point onward.
             for role in guild.roles[:0:-1]:  # top-down, excluding @everyone
-                if can_manage and role.name != Commands.client.user.name:
+                if can_manage:
                     roles.append(role.name)
                 elif Commands.client.user in role.members:
                     can_manage = True

--- a/src/commands/commands.py
+++ b/src/commands/commands.py
@@ -138,16 +138,19 @@ class Commands:
         )
         # ensure proper usage and get args
         args = list(map(str.lower, args))
+        aciton = ""
         if len(args) == 2: 
             action, target_name = args
         elif len(args) == 1:
             action = args[0]
             target_name = ""
-        else:
+
+        # TODO(nhawke): Change this to a dict with func vals when refactoring.
+        if action not in {'list', 'join', 'create', 'join', 'leave', 'delete'}:
             return help_message
             
         failure_msg = lambda msg='': CommandOutput().add_text(
-                f'Failed to {action} role {target_name}! {msg}')
+                f'Failed to {action} role "{target_name}"! {msg}')
         # TODO: factor this out to be common to all commands
         permission_msg = CommandOutput().add_text(
                 f'Memebot doesn\'t have permission to {action} role '
@@ -222,9 +225,13 @@ class Commands:
             return CommandOutput().add_text(
                     f'Created new role {new_role.mention}!')
         
-        # ensure role exists for remaining actions
+        # ensure role provided and exists for remaining actions
         if target_role is None: 
-            return failure_msg(f'The role `@{target_name}` was not found!')
+            if target_role == '':
+                msg = f'The role `@{target_name}` was not found!'
+            else:
+                msg = 'No role provided.'
+            return failure_msg(msg)
 
         # handle remaining actions
         if action == 'join':


### PR DESCRIPTION
supplying a command such as `!role ?` would return a failure message that was malformed due to the missing third argument. Now, catch this ahead of time and return a help message when the action is not among the known actions. 