### PR TITLE
Add all intents to bot

### DIFF
--- a/src/memebot.py
+++ b/src/memebot.py
@@ -11,7 +11,7 @@ class MemeBot(discord.Client):
     """
 
     def __init__(self, **args):
-        super().__init__(**args)
+        super().__init__(**args, intents=discord.Intents().all())
         global client
         if client is not None:
             raise ReferenceError("There can only be one Memebot!")


### PR DESCRIPTION
Adding privileges intents is now required for accessing members. Without
privileged intents, the author is None and the bot crashes.

This change also requires a change in the bot to give it access to privileged
intents. This should be done in the dev portal.

Fixes #51 