### PR TITLE
Commands module should automatically load commands

### DIFF
--- a/src/commands/__init__.py
+++ b/src/commands/__init__.py
@@ -1,49 +1,26 @@
-# The order of imports here could create circular dependencies... It might be a good idea to finish the current
-# machinery ASAP
+import importlib
+import os
+
 from . import registry, execution
-from .command import Command
-from .command_output import CommandOutput
-from commands.help import Help
-from commands.hello import Hello
-from commands.poll import Poll
-from commands.role import Role
-from commands.role.join import Join
-from commands.role.create import Create
-from commands.role.leave import Leave
-from commands.role.list import List
-from commands.role.delete import Delete
+from .command import Command, CommandOutput
 
 
-def dynamically_register_commands():
+def dynamically_register_commands() -> None:
     """
     Dynamically import all Command classes. Should only be called once outside of this function.
-    TODO This is to be implemented by #52
     """
-    raise NotImplementedError()
+
+    # Get all the packages located in the command package
+    top_level_packages = [f.path for f in os.scandir(os.path.dirname(os.path.realpath(__file__))) if
+                          f.is_dir() and not f.name.endswith("__pycache__")]
+
+    for path in top_level_packages:
+        pkg_name = os.path.basename(path)
+        pkg = importlib.import_module(f"commands.{pkg_name}")
+        cmd_class = getattr(pkg, pkg_name.capitalize())
+        if issubclass(cmd_class, Command):
+            cmd_class()
 
 
-# TODO Manually registering commands like this is a temporary solution which will be fixed by #52
-cmd_help = Help()
-registry.register_top_level_command(cmd_help)
-
-cmd_hello = Hello()
-registry.register_top_level_command(cmd_hello)
-
-cmd_poll = Poll()
-registry.register_top_level_command(cmd_poll)
-
-cmd_role = Role()
-cmd_role_create = Create()
-cmd_role_delete = Delete()
-cmd_role_join = Join()
-cmd_role_leave = Leave()
-cmd_role_list = List()
-role_parents = ["role"]
-registry.register_top_level_command(cmd_role)
-registry.register_subcommand(role_parents, cmd_role_create)
-registry.register_subcommand(role_parents, cmd_role_delete)
-registry.register_subcommand(role_parents, cmd_role_join)
-registry.register_subcommand(role_parents, cmd_role_leave)
-registry.register_subcommand(role_parents, cmd_role_list)
-
+dynamically_register_commands()
 registry.lock()

--- a/src/commands/__init__.py
+++ b/src/commands/__init__.py
@@ -15,9 +15,12 @@ def dynamically_register_commands() -> None:
                           f.is_dir() and not f.name.endswith("__pycache__")]
 
     for path in top_level_packages:
-        pkg_name = os.path.basename(path)
-        pkg = importlib.import_module(f"commands.{pkg_name}")
-        cmd_class = getattr(pkg, pkg_name.capitalize())
+        class_and_pkg_name = os.path.basename(path)
+        # First we import the package
+        pkg = importlib.import_module(f"commands.{class_and_pkg_name}")
+        # Then, we retrieve the class from the imported package
+        cmd_class = getattr(pkg, class_and_pkg_name.capitalize())
+        # If the retrieved class is a Command, initialize it
         if issubclass(cmd_class, Command):
             cmd_class()
 

--- a/src/commands/__init__.py
+++ b/src/commands/__init__.py
@@ -22,7 +22,19 @@ def dynamically_register_commands() -> None:
         cmd_class = getattr(pkg, class_and_pkg_name.capitalize())
         # If the retrieved class is a Command, initialize it
         if issubclass(cmd_class, Command):
-            cmd_class()
+            instance = cmd_class()
+            # Registration machinery:
+            # If the command is a top-level command
+            if type(cmd_class.parent) is Command:
+                registry.register_top_level_command(instance)
+            else:
+                parents = []
+                parent = cmd_class.parent
+                # Gather all of this subcommand's parents
+                while type(parent) is not Command:
+                    parents.append(parent.name)
+                    parent = parent.__class__.parent
+                registry.register_subcommand(parents, instance)
 
 
 dynamically_register_commands()

--- a/src/commands/command.py
+++ b/src/commands/command.py
@@ -41,7 +41,7 @@ class Command(metaclass=CommandMeta):
         """
         if name is None:
             raise ValueError(f"Every command needs to have a name! ({type(self).__name__})")
-        if not name.islower() or any(not c.isalpha() for c in name):
+        if not (name.islower() and name.isalpha()):
             raise ValueError(f"Command names must be a single word, all lowercase! ({name})")
         self.name: str = name
         if description is None:

--- a/src/commands/command.py
+++ b/src/commands/command.py
@@ -1,12 +1,27 @@
 from abc import abstractmethod
-from typing import List, Callable, Union, Tuple
+from typing import List, Callable, Union, Tuple, Type
 
 import discord
 
+from commands import registry
 from commands.command_output import CommandOutput
 
 
-class Command:
+class CommandMeta(type):
+    """
+    Metaclass that establishes appropriate relationships to other commands
+    """
+
+    def __init__(cls, name, bases, dct) -> None:
+        super().__init__(cls)
+        if cls.__name__ == "Command":
+            cls.parent: None
+        else:
+            cls.parent: Command = Command("default", "")
+        cls.subcommands: List[Command] = []
+
+
+class Command(metaclass=CommandMeta):
     """
     Defines a base command. This class itself should never be instantiated, but MUST be implemented by every command
     used by Memebot. Each Comamnd has a required set of attributes:
@@ -26,15 +41,27 @@ class Command:
         """
         if name is None:
             raise ValueError(f"Every command needs to have a name! ({type(self).__name__})")
-        if not name.islower() or any(c.isspace() for c in name):
+        if not name.islower() or any(not c.isalpha() for c in name):
             raise ValueError(f"Command names must be a single word, all lowercase! ({name})")
         self.name: str = name
         if description is None:
             raise ValueError(f"Every command needs to have a description! ({type(self).__name__})")
         self.description: str = description
         self.example_args: str = example_args
-        # TODO rushed temporary solution. Perhaps un-self-referential Commands should be rethought entirely...
-        self.parent: Union[str, None] = None
+        # Registration machinery:
+        if self.__class__.__name__ == "Command":
+            return
+        # If the command is a top-level command
+        elif type(self.parent) is Command:
+            registry.register_top_level_command(self)
+        else:
+            parents = []
+            parent = self.parent
+            # Gather all of this subcommand's parents
+            while type(parent) is not Command:
+                parents.append(parent.name)
+                parent = parent.__class__.parent
+            registry.register_subcommand(parents, self)
 
     def __repr__(self) -> str:
         return f"Command: {type(self).__name__}(name={self.name} description={self.description})"
@@ -55,10 +82,18 @@ class Command:
         information desired, at discretion of the developer.
         :return: Information to be presented to the server upon failure of this command.
         """
+        parent_list = []
+        current_parent = self.parent
+        while type(current_parent) is not Command:
+            parent_list.append(current_parent.name)
+            current_parent = self.parent
+        cmd_preamble = ' '.join(parent_list)
+        if len(cmd_preamble) > 0:
+            cmd_preamble += ' '
         output = self.help_text().append_line(
-            f"**`!{self.name if self.parent is None else f'{self.parent} {self.name}'}" + (
-                f" {self.example_args}`**" if len(self.example_args) > 0 else "`**"))
+            f"**`!{cmd_preamble}{self.name}" + (f" {self.example_args}`**" if len(self.example_args) > 0 else "`**"))
         if additional_info:
+            output.append_line("")
             output.append_line(additional_info)
         return output
 
@@ -81,3 +116,25 @@ class Command:
         after the first response (i.e. the return value of Command.exec) is sent to the server.
         """
         pass
+
+
+class has_subcommands:
+    """
+    Modifies a command's constructor such that it will register itself and all subcommands when instantiated
+    """
+
+    def __init__(self, *subcommands: Type[Command]) -> None:
+        self.subcommands = subcommands
+
+    def __call__(self, cmd: Type[Command]):
+        original_init = cmd.__init__
+
+        def __init__(inner_self):
+            original_init(inner_self)
+            for sub in self.subcommands:
+                sub.parent = inner_self
+                cmd.subcommands.append(sub())
+
+        cmd.__init__ = __init__
+
+        return cmd

--- a/src/commands/command.py
+++ b/src/commands/command.py
@@ -3,7 +3,6 @@ from typing import List, Callable, Union, Tuple, Type
 
 import discord
 
-from commands import registry
 from commands.command_output import CommandOutput
 
 
@@ -48,20 +47,6 @@ class Command(metaclass=CommandMeta):
             raise ValueError(f"Every command needs to have a description! ({type(self).__name__})")
         self.description: str = description
         self.example_args: str = example_args
-        # Registration machinery:
-        if self.__class__.__name__ == "Command":
-            return
-        # If the command is a top-level command
-        elif type(self.__class__.parent) is Command:
-            registry.register_top_level_command(self)
-        else:
-            parents = []
-            parent = self.__class__.parent
-            # Gather all of this subcommand's parents
-            while type(parent) is not Command:
-                parents.append(parent.name)
-                parent = parent.__class__.parent
-            registry.register_subcommand(parents, self)
 
     def __repr__(self) -> str:
         return f"Command: {type(self).__name__}(name={self.name} description={self.description})"

--- a/src/commands/command.py
+++ b/src/commands/command.py
@@ -52,11 +52,11 @@ class Command(metaclass=CommandMeta):
         if self.__class__.__name__ == "Command":
             return
         # If the command is a top-level command
-        elif type(self.parent) is Command:
+        elif type(self.__class__.parent) is Command:
             registry.register_top_level_command(self)
         else:
             parents = []
-            parent = self.parent
+            parent = self.__class__.parent
             # Gather all of this subcommand's parents
             while type(parent) is not Command:
                 parents.append(parent.name)

--- a/src/commands/help/__init__.py
+++ b/src/commands/help/__init__.py
@@ -2,8 +2,8 @@ from typing import List
 
 import discord
 
-from ..command import Command, CommandOutput
-from ..registry import top_level_command_registry
+from commands import Command, CommandOutput
+from commands.registry import top_level_command_registry
 
 
 class Help(Command):

--- a/src/commands/registry.py
+++ b/src/commands/registry.py
@@ -4,7 +4,7 @@ Commands module, but the registry can be _read_ at any time.
 """
 from typing import Dict, List, Tuple
 
-from .command import Command
+from commands.command import Command
 
 DEFAULT_COMMAND = "help"
 

--- a/src/commands/role/__init__.py
+++ b/src/commands/role/__init__.py
@@ -1,10 +1,16 @@
-from typing import List
-
+import typing
 import discord
 
 from commands import Command, CommandOutput
+from .create import Create
+from .delete import Delete
+from .join import Join
+from .leave import Leave
+from .list import List
+from ..command import has_subcommands
 
 
+@has_subcommands(Create, Delete, Join, Leave, List)
 class Role(Command):
     """
     Controls creating, joining, and leaving permissonless mentionable
@@ -31,15 +37,9 @@ class Role(Command):
             "intended to serve as \"tags\" to allow mentioning multiple users at once."
         )
 
-    async def exec(self, args: List[str], message: discord.Message) -> CommandOutput:
-        # TODO Create a general way of harvesting subcommands and formatting it like this in Command.fail()
-        return self.fail(f"""
-`!{self.name} create <role>`: Creates <role>
-`!{self.name} join <role>`: Adds caller to <role>
-`!{self.name} leave <role>`: Removes caller from <role>
-`!{self.name} delete <role>`: Deletes <role> if <role> has no members
-`!{self.name} list`: Lists all bot-managed roles
-`!{self.name} list <role>`: Lists members of <role>""")
+    async def exec(self, args: typing.List[str], message: discord.Message) -> CommandOutput:
+        return self.fail(
+            '\n'.join(f"`!{self.name} {sub.name} {sub.example_args}`: {sub.description}" for sub in Role.subcommands))
 
 
 def action_failure_message(action: str, target_name: str, msg: str = "") -> CommandOutput:

--- a/src/commands/role/__init__.py
+++ b/src/commands/role/__init__.py
@@ -1,13 +1,14 @@
 import typing
+
 import discord
 
 from commands import Command, CommandOutput
+from commands.command import has_subcommands
 from .create import Create
 from .delete import Delete
 from .join import Join
 from .leave import Leave
 from .list import List
-from ..command import has_subcommands
 
 
 @has_subcommands(Create, Delete, Join, Leave, List)

--- a/src/commands/role/create.py
+++ b/src/commands/role/create.py
@@ -12,7 +12,6 @@ class Create(Command):
 
     def __init__(self):
         super().__init__("create", "Creates <role>", "<role>")
-        self.parent = "role"
 
     def help_text(self) -> CommandOutput:
         return CommandOutput().set_text("Create a new role to be managed by memebot.")

--- a/src/commands/role/delete.py
+++ b/src/commands/role/delete.py
@@ -12,7 +12,6 @@ class Delete(Command):
 
     def __init__(self):
         super().__init__("delete", "Deletes <role> if <role> has no members.", "<role>")
-        self.parent = "role"
 
     def help_text(self) -> CommandOutput:
         return CommandOutput().set_text("Delete a Memebot-managed role if, and only if, the role has no members.")
@@ -42,4 +41,3 @@ class Delete(Command):
                 return CommandOutput().set_text(f"Deleted role `@{target_name}`")
         else:
             return role.action_failure_message(self.name, target_name, 'Roles must have no members to be deleted.')
-

--- a/src/commands/role/join.py
+++ b/src/commands/role/join.py
@@ -12,7 +12,6 @@ class Join(Command):
 
     def __init__(self):
         super().__init__("join", "Adds caller to <role>", "<role>")
-        self.parent = "role"
 
     def help_text(self) -> CommandOutput:
         return CommandOutput().set_text("Join an existing Memebot-managed role.")

--- a/src/commands/role/leave.py
+++ b/src/commands/role/leave.py
@@ -12,7 +12,6 @@ class Leave(Command):
 
     def __init__(self):
         super().__init__("leave", "Removes caller from <role>", "<role>")
-        self.parent = "role"
 
     def help_text(self) -> CommandOutput:
         return CommandOutput().set_text("Leave a Memebot-managed role.")

--- a/src/commands/role/list.py
+++ b/src/commands/role/list.py
@@ -13,7 +13,6 @@ class List(Command):
 
     def __init__(self):
         super().__init__("list", "List all roles managed by Memebot, or list all members of a role.", "[role]")
-        self.parent = "role"
 
     def help_text(self) -> CommandOutput:
         return CommandOutput().set_text("List all roles managed by Memebot, or provide the name of a role and list "


### PR DESCRIPTION
**Does this improvement fix a bug/issue? Please describe.**
N/A

**What do you dislike about the feature in its current state?**
Commands have to be manually registered in the constructor, which is inconvenient and unnecessary work for the command implementer.

**Describe the solution you'd like**
Dynamically load the the individual command modules when the `command` module loads, i.e. in `commands/__init__.py`. There is currently a placeholder function where this should take place.

**What tradeoffs are made by implementing your improvement?**
Adds a minor layer of complexity to command infrastructure, but is unlikely to need changes unless a command with wildly different format is created.

**Describe alternatives you've considered**
Manually adding commands is not a terrible solution, and solving this problem is pretty hard. 

**Additional context** 
With the refactors made in #39 , the command infrastructure was reworked in every desirable way except for automatic command module loading because Discord introduced [breaking changes](https://discordpy.readthedocs.io/en/latest/whats_new.html#v1-5-0) in their API and we needed to rush through the command module refactor so we could fix the `!role` command (see #51).)