### PR TITLE
Command callbacks are called regardless of whether or not command fails

### DIFF
--- a/src/commands/command.py
+++ b/src/commands/command.py
@@ -4,6 +4,7 @@ from typing import List, Callable, Union, Tuple, Type
 import discord
 
 from commands.command_output import CommandOutput
+from lib import status
 
 
 class CommandMeta(type):
@@ -80,6 +81,7 @@ class Command(metaclass=CommandMeta):
         if additional_info:
             output.append_line("")
             output.append_line(additional_info)
+        output.status = status.FAIL
         return output
 
     @abstractmethod

--- a/src/commands/command_output.py
+++ b/src/commands/command_output.py
@@ -3,6 +3,8 @@ from typing import Union, KeysView, ValuesView, List
 
 import discord
 
+from lib import status
+
 
 class CommandOutput:
     """
@@ -17,11 +19,16 @@ class CommandOutput:
     LIFETIME = 'delete_after'
     NONCE = 'nonce'
 
-    def __init__(self, kwargs: dict = None):
+    def __init__(self, kwargs: dict = None, status: int = status.SUCCESS):
+        """
+        :param kwargs: A keyword-arguments dictionary
+        :param status: The status of the command, whose value should be taken 
+        from lib.status
+        """
+        self.status: int = status
         if type(kwargs) is dict:
             self.kwargs = kwargs
         else:
-            # dict to hold keyword arguments
             self.kwargs = {}
 
     def __repr__(self) -> str:

--- a/src/commands/command_output.py
+++ b/src/commands/command_output.py
@@ -19,13 +19,13 @@ class CommandOutput:
     LIFETIME = 'delete_after'
     NONCE = 'nonce'
 
-    def __init__(self, status: int = status.SUCCESS, **kwargs):
+    def __init__(self, command_status: int = status.SUCCESS, **kwargs):
         """
         :param kwargs: A keyword-arguments dictionary
-        :param status: The status of the command, whose value should be taken
+        :param command_status: The status of the command, whose value should be taken
         from lib.status
         """
-        self.status: int = status
+        self.status: int = command_status
         if type(kwargs) is dict:
             self.kwargs = kwargs
         else:
@@ -134,9 +134,6 @@ class CommandOutput:
 
     def __contains__(self, item: str) -> bool:
         return item in self.kwargs
-
-    def __add__(self, other: 'CommandOutput') -> 'CommandOutput':
-        return CommandOutput(**self.kwargs.update(other.kwargs))
 
     def keys(self) -> KeysView[str]:
         return self.kwargs.keys()

--- a/src/commands/role/__init__.py
+++ b/src/commands/role/__init__.py
@@ -4,6 +4,7 @@ import discord
 
 from commands import Command, CommandOutput
 from commands.command import has_subcommands
+from lib import status
 from .create import Create
 from .delete import Delete
 from .join import Join
@@ -51,7 +52,7 @@ def action_failure_message(action: str, target_name: str, msg: str = "") -> Comm
     :param msg: The explanation, usually extracted from an exception.
     :return: A CommandOutput with the created message.
     """
-    return CommandOutput().set_text(f"Failed to {action} role {target_name}! {msg}")
+    return CommandOutput(status=status.FAIL).set_text(f"Failed to {action} role {target_name}! {msg}")
 
 
 def permission_failure_message(action: str, target_name: str) -> CommandOutput:
@@ -62,8 +63,8 @@ def permission_failure_message(action: str, target_name: str) -> CommandOutput:
     :return: A CommandOutput with the created message.
     """
     # TODO: factor this out to be common to all commands
-    return CommandOutput().set_text(f"Memebot doesn't have permission to {action} role {target_name}. "
-                                    "Are you sure you configured Membot's permissions correctly?")
+    return CommandOutput(status=status.FAIL).set_text(f"Memebot doesn't have permission to {action} role {target_name}. "
+                                                       "Are you sure you configured Membot's permissions correctly?")
 
 
 def find_role_by_name(target_name: str, guild: discord.Guild) -> discord.Role:

--- a/src/commands/role/__init__.py
+++ b/src/commands/role/__init__.py
@@ -52,7 +52,7 @@ def action_failure_message(action: str, target_name: str, msg: str = "") -> Comm
     :param msg: The explanation, usually extracted from an exception.
     :return: A CommandOutput with the created message.
     """
-    return CommandOutput(status=status.FAIL).set_text(f"Failed to {action} role {target_name}! {msg}")
+    return CommandOutput(command_status=status.FAIL).set_text(f"Failed to {action} role {target_name}! {msg}")
 
 
 def permission_failure_message(action: str, target_name: str) -> CommandOutput:
@@ -63,7 +63,7 @@ def permission_failure_message(action: str, target_name: str) -> CommandOutput:
     :return: A CommandOutput with the created message.
     """
     # TODO: factor this out to be common to all commands
-    return CommandOutput(status=status.FAIL).set_text(f"Memebot doesn't have permission to {action} role {target_name}. "
+    return CommandOutput(command_status=status.FAIL).set_text(f"Memebot doesn't have permission to {action} role {target_name}. "
                                                        "Are you sure you configured Membot's permissions correctly?")
 
 

--- a/src/lib/status.py
+++ b/src/lib/status.py
@@ -1,0 +1,6 @@
+"""
+This is where we will put status codes for various operations.
+"""
+
+SUCCESS = 0
+FAIL = -1


### PR DESCRIPTION
**Description**
If a Command fails for whatever reason, there is nothing to communicate the outcome of the command and the callback is called regardless.

**To Reproduce**
1. Run `!poll`
2. Observe that the callback runs even though the command fails gracefully

**Expected behavior**
On command failure, the callback should be skipped. 

**Additional context**
We could maybe optionally allow a callback to run if commands fail under certain circumstances, but I can't imagine a scenario where regular cleanup in `Command.exec` would not suffice.