### PR TITLE
Fix subcommand registration

### DIFF
--- a/src/commands/__init__.py
+++ b/src/commands/__init__.py
@@ -15,9 +15,7 @@ def dynamically_register_commands() -> None:
         # Do a depth-first search to register subcommands
         for subcommand in top_level_command.subcommands:
             registry.register_subcommand(cmd_path, subcommand)
-            cmd_path.append(subcommand.name)
-            find_and_register_subcommands(subcommand, cmd_path)
-            cmd_path.pop()
+            find_and_register_subcommands(subcommand, cmd_path + [subcommand.name])
 
     # Get all the packages located in the command package
     top_level_packages = [f.path for f in os.scandir(os.path.dirname(os.path.realpath(__file__))) if

--- a/src/commands/__init__.py
+++ b/src/commands/__init__.py
@@ -1,5 +1,6 @@
 import importlib
 import os
+from typing import List
 
 from . import registry, execution
 from .command import Command, CommandOutput
@@ -9,6 +10,14 @@ def dynamically_register_commands() -> None:
     """
     Dynamically import all Command classes. Should only be called once outside of this function.
     """
+
+    def find_and_register_subcommands(top_level_command: Command, cmd_path: List[str]) -> None:
+        # Do a depth-first search to register subcommands
+        for subcommand in top_level_command.subcommands:
+            registry.register_subcommand(cmd_path, subcommand)
+            cmd_path.append(subcommand.name)
+            find_and_register_subcommands(subcommand, cmd_path)
+            cmd_path.pop()
 
     # Get all the packages located in the command package
     top_level_packages = [f.path for f in os.scandir(os.path.dirname(os.path.realpath(__file__))) if
@@ -27,14 +36,7 @@ def dynamically_register_commands() -> None:
             # If the command is a top-level command
             if type(cmd_class.parent) is Command:
                 registry.register_top_level_command(instance)
-            else:
-                parents = []
-                parent = cmd_class.parent
-                # Gather all of this subcommand's parents
-                while type(parent) is not Command:
-                    parents.append(parent.name)
-                    parent = parent.__class__.parent
-                registry.register_subcommand(parents, instance)
+                find_and_register_subcommands(instance, [instance.name])
 
 
 dynamically_register_commands()


### PR DESCRIPTION
I am not sure how this functionality ever worked tbh.

The latest commit on master as of right now does not register any subcommands.

Subcommand registration is now done top-down, using a recursive depth-first search. If you can think of a way to do it iteratively, please comment.
