### PR TITLE
Fix role double-join errors

### DIFF
--- a/src/commands/role/__init__.py
+++ b/src/commands/role/__init__.py
@@ -63,7 +63,7 @@ def permission_failure_message(action: str, target_name: str) -> CommandOutput:
     :return: A CommandOutput with the created message.
     """
     # TODO: factor this out to be common to all commands
-    return CommandOutput(command_status=status.FAI).set_text(f"Memebot doesn't have permission to {action} role `@{target_name}`. "
+    return CommandOutput(command_status=status.FAIL).set_text(f"Memebot doesn't have permission to {action} role `@{target_name}`. "
                                     "Are you sure you configured Membot's permissions correctly?")
 
 

--- a/src/commands/role/__init__.py
+++ b/src/commands/role/__init__.py
@@ -51,7 +51,7 @@ def action_failure_message(action: str, target_name: str, msg: str = "") -> Comm
     :param msg: The explanation, usually extracted from an exception.
     :return: A CommandOutput with the created message.
     """
-    return CommandOutput().set_text(f"Failed to {action} role {target_name}! {msg}")
+    return CommandOutput().set_text(f"Failed to {action} role `@{target_name}`! {msg}")
 
 
 def permission_failure_message(action: str, target_name: str) -> CommandOutput:
@@ -62,7 +62,7 @@ def permission_failure_message(action: str, target_name: str) -> CommandOutput:
     :return: A CommandOutput with the created message.
     """
     # TODO: factor this out to be common to all commands
-    return CommandOutput().set_text(f"Memebot doesn't have permission to {action} role {target_name}. "
+    return CommandOutput().set_text(f"Memebot doesn't have permission to {action} role `@{target_name}`. "
                                     "Are you sure you configured Membot's permissions correctly?")
 
 

--- a/src/commands/role/__init__.py
+++ b/src/commands/role/__init__.py
@@ -63,8 +63,9 @@ def permission_failure_message(action: str, target_name: str) -> CommandOutput:
     :return: A CommandOutput with the created message.
     """
     # TODO: factor this out to be common to all commands
-    return CommandOutput(command_status=status.FAIL).set_text(f"Memebot doesn't have permission to {action} role `@{target_name}`. "
-                                    "Are you sure you configured Membot's permissions correctly?")
+    return CommandOutput(command_status=status.FAIL,
+                         content=f"Memebot doesn't have permission to {action} role `@{target_name}`. "
+                                  "Are you sure you configured Membot's permissions correctly?")
 
 
 def find_role_by_name(target_name: str, guild: discord.Guild) -> discord.Role:

--- a/src/commands/role/join.py
+++ b/src/commands/role/join.py
@@ -26,6 +26,8 @@ class Join(Command):
         target_role = role.find_role_by_name(target_name, message.guild)
         if target_role is None:
             return role.action_failure_message(self.name, target_name, f'The role `@{target_name}` was not found!')
+        if author in target_role.members :
+            return role.action_failure_message(self.name, target_name, f'User is already a member of `@{target_name}`.')
 
         try:
             await author.add_roles(target_role, reason=role.get_reason(author.name))


### PR DESCRIPTION
Now, when a user joins a role they are already a member of, a proper
error message is sent instead of a duplicate success message.

fixes #49 