### PR TITLE
Support config through command-line parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ optional arguments:
 
 Current commands that can be used in Discord:
 
-    !help - Learn how to use MemeBot
-    !poll - Create a simple poll.
     !hello - Say "hello" to Memebot!
-    !role - Self-contained role management
+    !help  - Learn how to use MemeBot
+    !poll  - Create a simple poll.
+    !role  - Self-contained role management
 
 ## Docker
 Memebot has a straightforward Docker image that can be build based on the [Dockerfile](./Dockerfile) in this 

--- a/README.md
+++ b/README.md
@@ -4,20 +4,26 @@ This is MemeBot, a discord bot.
 
 If you are hosting yourself, you will need to create a file in the root directory of your local repository called 
 `client_token` and paste your Discord developer client token into that file. Nothing else should be in the file.
-From there, to run the bot, simply run the following command from the root of the project:
+Usage of the bot is as follows:
 
-```bash
-python3 src/main.py
+```
+usage: main.py [-h] [--discord-api-token DISCORD_API_TOKEN] [--twitter-api-tokens TWITTER_API_TOKENS]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --discord-api-token DISCORD_API_TOKEN
+                        Path to the file containing the Discord API token
+  --twitter-api-tokens TWITTER_API_TOKENS
+                        Path to the file containing the Twitter API tokens, in JSON format.
 ```
 
 Current commands that can be used in Discord:
-    
-    !help  - display help text
-    !hello - print "Hello!"
-    !poll  - create a simple poll
-    !role  - manage mentionable roles
+
+    !help - Learn how to use MemeBot
+    !poll - Create a simple poll.
+    !hello - Say "hello" to Memebot!
+    !role - Self-contained role management
 
 ## Docker
 Memebot has a straightforward Docker image that can be build based on the [Dockerfile](./Dockerfile) in this 
-repository. This image can be used for both deployment and testing purposes, although regular testing with it is not 
-recommended, as the image has to be rebuilt any time a file is edited or a configuration is changed.
+repository. This image can be used for both deployment and testing purposes.

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -1,0 +1,29 @@
+import argparse
+import pathlib
+
+discord_api_token: pathlib.Path
+twitter_api_tokens: pathlib.Path
+
+
+def populate_config_from_command_line():
+    parser = argparse.ArgumentParser()
+
+    # API Tokens
+    parser.add_argument("--discord-api-token",
+                        help="Path to the file containing the Discord API token",
+                        default="client_token",
+                        type=pathlib.Path)
+    parser.add_argument("--twitter-api-tokens",
+                        help="Path to the file containing the Twitter API tokens, in JSON format.",
+                        default="twitter_api_tokens.json",
+                        type=pathlib.Path)
+
+    args = parser.parse_args()
+
+    global discord_api_token
+    global twitter_api_tokens
+    discord_api_token = args.discord_api_token
+    twitter_api_tokens = args.twitter_api_tokens
+
+
+populate_config_from_command_line()

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,6 @@
 import sys
 
+import config
 from memebot import MemeBot
 
 
@@ -11,7 +12,7 @@ def main() -> int:
     client = MemeBot()
 
     # !! DO NOT HARDCODE THE TOKEN !!
-    with open('client_token') as token_file:
+    with open(config.discord_api_token) as token_file:
         token = token_file.read().strip()
 
     return client.run(token)

--- a/src/memebot.py
+++ b/src/memebot.py
@@ -6,6 +6,7 @@ import discord
 import twitter
 
 import commands
+import config
 from lib import constants
 
 
@@ -21,7 +22,7 @@ class MemeBot(discord.Client):
             raise ReferenceError("There can only be one Memebot!")
         client = self
 
-        with open('twitter_api_tokens.json') as twitter_api_tokens:
+        with open(config.twitter_api_tokens) as twitter_api_tokens:
             twitter_tokens = json.load(twitter_api_tokens)
 
         self.twitter_api = twitter.Api(


### PR DESCRIPTION
Memebot now has the framework for manual reconfig through command-line parameters. Currently, the only two supported options are:

```
--discord-api-token
--twitter-api-tokens
```

In the future, being able to add command-line parameters will make testing and configuring the bot much easier.
