### PR TITLE
Migrate Twitter integration to tweepy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 discord.py
-python-twitter
+tweepy

--- a/src/memebot.py
+++ b/src/memebot.py
@@ -71,8 +71,7 @@ class MemeBot(discord.Client):
 
             if tweet_info.is_quote_status:
                 quote_tweet_urls = self.get_quote_tweet_urls(tweet_info)
-                if quote_tweet_urls:
-                    await message.channel.send(quote_tweet_urls)
+                await message.channel.send(quote_tweet_urls)
 
     def get_twitter_url_from_message(self, content: str) -> str:
         """
@@ -92,16 +91,13 @@ class MemeBot(discord.Client):
         :param tweet_info: information of tweet
         :return: URL of media/quote tweet(s)
         """
-        tweets = ""
-        for level in range(3):
+        tweets = "quoted tweet(s): "
+        for _ in range(3):
             tweets += "\nhttps://twitter.com/" + tweet_info.quoted_status.author.screen_name + "/status/" + tweet_info.quoted_status.id_str
             tweet_info = self.twitter_api.get_status(tweet_info.quoted_status.id)
             if not tweet_info.is_quote_status:
                 break
-        if not tweets:
-            return ""
-        else:
-            return "quoted tweet(s): " + tweets
+        return tweets
 
 
 client: Optional[discord.Client] = None


### PR DESCRIPTION
The python-twitter package is fully replaced by Tweepy, plus a few minor optimizations:

1. The tweet-checking regex now runs against the entire message, instead of once per word. The Twitter URL is then extracted via group matching.
2. Some functions have been renamed to be more clear.
3. Extracted quote tweet URLs now follow the `twitter.com/user/status/1234` format instead of `twitter.com/i/web/1234`.
4. API access is now by default read-only.

This patch was fairly painless, as tweepy happens to be reasonably similar to python-twitter.

Fixes #63.
