### PR TITLE
Make `memebot.client` non-nullable

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,7 +1,7 @@
 import sys
 
 import config
-from memebot import MemeBot
+import memebot
 
 
 def main() -> int:
@@ -9,7 +9,7 @@ def main() -> int:
     Main function, initializes MemeBot and then loops
     :return: Exit status of discord.Client.run()
     """
-    client = MemeBot()
+    client = memebot.client
 
     # !! DO NOT HARDCODE THE TOKEN !!
     with open(config.discord_api_token) as token_file:

--- a/src/memebot.py
+++ b/src/memebot.py
@@ -1,6 +1,5 @@
 import json
 import re
-from typing import Optional
 
 import discord
 import tweepy
@@ -17,10 +16,6 @@ class MemeBot(discord.Client):
 
     def __init__(self, **args):
         super().__init__(**args, intents=discord.Intents().all())
-        global client
-        if client is not None:
-            raise ReferenceError("There can only be one Memebot!")
-        client = self
 
         with open(config.twitter_api_tokens) as twitter_api_tokens:
             twitter_tokens = json.load(twitter_api_tokens)
@@ -100,4 +95,4 @@ class MemeBot(discord.Client):
         return tweets
 
 
-client: Optional[discord.Client] = None
+client: discord.Client = MemeBot()


### PR DESCRIPTION
Cleaned up a small bit of `MemeBot` code to make it so that the `MemeBot` constructor does not populate the global variable `memebot.client`, and that variable is instead populated at module-load time. This way, it is never null, and we can ensure that everyone is accessing the same `MemeBot` object (as best we can without a `const` qualifier, anyway.)
