### PR TITLE
Allow `!role` command to be used with @ mentions

### DIFF
--- a/src/commands/role/__init__.py
+++ b/src/commands/role/__init__.py
@@ -75,7 +75,8 @@ def find_role_by_name(target_name: str, guild: discord.Guild) -> discord.Role:
     :param guild: The guild to search through.
     :return: A discord.Role object with the same name as ``target_name``.
     """
-    # First we check to see if the target_name is an `@` mention
+    # First we check to see if the target_name is an `@` mention, which would be indicated by
+    # a string that looks like <@&1234567890>.
     role_id = 0
     try:
         id_str = target_name[3:len(target_name) - 1]
@@ -86,6 +87,7 @@ def find_role_by_name(target_name: str, guild: discord.Guild) -> discord.Role:
         mentioned_role = guild.get_role(role_id)
     if mentioned_role:
         return mentioned_role
+    # If the target_name is not an @ mention, we search for an existing role with an equal name.
     for role in guild.roles:
         if role.name == target_name:
             return role

--- a/src/commands/role/__init__.py
+++ b/src/commands/role/__init__.py
@@ -79,12 +79,10 @@ def find_role_by_name(target_name: str, guild: discord.Guild) -> discord.Role:
     # a string that looks like <@&1234567890>.
     role_id = 0
     try:
-        id_str = target_name[3:len(target_name) - 1]
-        role_id = int(id_str)
-    except ValueError:
+        role_id = int(target_name[3:-1])
+    except (ValueError, IndexError):
         pass
-    finally:
-        mentioned_role = guild.get_role(role_id)
+    mentioned_role = guild.get_role(role_id)
     if mentioned_role:
         return mentioned_role
     # If the target_name is not an @ mention, we search for an existing role with an equal name.

--- a/src/commands/role/__init__.py
+++ b/src/commands/role/__init__.py
@@ -65,7 +65,7 @@ def permission_failure_message(action: str, target_name: str) -> CommandOutput:
     # TODO: factor this out to be common to all commands
     return CommandOutput(command_status=status.FAIL,
                          content=f"Memebot doesn't have permission to {action} role `@{target_name}`. "
-                                  "Are you sure you configured Membot's permissions correctly?")
+                                 "Are you sure you configured Membot's permissions correctly?")
 
 
 def find_role_by_name(target_name: str, guild: discord.Guild) -> discord.Role:
@@ -75,6 +75,17 @@ def find_role_by_name(target_name: str, guild: discord.Guild) -> discord.Role:
     :param guild: The guild to search through.
     :return: A discord.Role object with the same name as ``target_name``.
     """
+    # First we check to see if the target_name is an `@` mention
+    role_id = 0
+    try:
+        id_str = target_name[3:len(target_name) - 1]
+        role_id = int(id_str)
+    except ValueError:
+        pass
+    finally:
+        mentioned_role = guild.get_role(role_id)
+    if mentioned_role:
+        return mentioned_role
     for role in guild.roles:
         if role.name == target_name:
             return role

--- a/src/commands/role/create.py
+++ b/src/commands/role/create.py
@@ -22,7 +22,9 @@ class Create(Command):
 
         guild = message.guild
         author = guild.get_member(message.author.id)
-        target_name = args[0].lower().lstrip('@')
+        target_name = args[0].lower()
+        if '@' in target_name:
+            return role.action_failure_message(self.name, target_name, "Created roles cannot contain the `@` symbol.")
         target_role = role.find_role_by_name(target_name, message.guild)
         if target_role is not None:
             return role.action_failure_message(self.name, target_name, f'The role `@{target_name}` already exists!')

--- a/src/commands/role/create.py
+++ b/src/commands/role/create.py
@@ -22,7 +22,7 @@ class Create(Command):
 
         guild = message.guild
         author = guild.get_member(message.author.id)
-        target_name = args[0].lower()
+        target_name = args[0].lower().lstrip('@')
         target_role = role.find_role_by_name(target_name, message.guild)
         if target_role is not None:
             return role.action_failure_message(self.name, target_name, f'The role `@{target_name}` already exists!')

--- a/src/commands/role/delete.py
+++ b/src/commands/role/delete.py
@@ -32,12 +32,12 @@ class Delete(Command):
             try:
                 await target_role.delete(reason=role.get_reason(author.name))
             except discord.Forbidden:
-                print(f'!role: Forbidden: delete( {target_name} )')
+                print(f'!role: Forbidden: delete( {target_role.name} )')
                 return role.permission_failure_message(self.name, target_name)
             except discord.HTTPException:
-                print(f'!role: Failed API call delete( {target_name} )')
-                return role.action_failure_message(self.name, target_name)
+                print(f'!role: Failed API call delete( {target_role.name} )')
+                return role.action_failure_message(self.name, target_role.name)
             finally:
-                return CommandOutput().set_text(f"Deleted role `@{target_name}`")
+                return CommandOutput().set_text(f"Deleted role `@{target_role.name}`")
         else:
-            return role.action_failure_message(self.name, target_name, 'Roles must have no members to be deleted.')
+            return role.action_failure_message(self.name, target_role.name, 'Roles must have no members to be deleted.')

--- a/src/commands/role/join.py
+++ b/src/commands/role/join.py
@@ -27,15 +27,15 @@ class Join(Command):
         if target_role is None:
             return role.action_failure_message(self.name, target_name, f'The role `@{target_name}` was not found!')
         if author in target_role.members :
-            return role.action_failure_message(self.name, target_name, f'User is already a member of `@{target_name}`.')
+            return role.action_failure_message(self.name, target_role.name, f'User is already a member of `@{target_role.name}`.')
 
         try:
             await author.add_roles(target_role, reason=role.get_reason(author.name))
         except discord.Forbidden:
-            print(f'!role: Forbidden: {author.name}.add_role( {target_name} )')
-            return role.permission_failure_message(self.name, target_name)
+            print(f'!role: Forbidden: {author.name}.add_role( {target_role.name} )')
+            return role.permission_failure_message(self.name, target_role.name)
         except discord.HTTPException:
-            print(f'!role: Failed API call: {author.name}.add_role( {target_name} )')
-            return role.action_failure_message(self.name, target_name)
+            print(f'!role: Failed API call: {author.name}.add_role( {target_role.name} )')
+            return role.action_failure_message(self.name, target_role.name)
         finally:
-            return CommandOutput().set_text(f"{author.name} successfully joined `@{target_name}`")
+            return CommandOutput().set_text(f"{author.name} successfully joined `@{target_role.name}`")

--- a/src/commands/role/leave.py
+++ b/src/commands/role/leave.py
@@ -30,10 +30,10 @@ class Leave(Command):
         try:
             await author.remove_roles(target_role, reason=role.get_reason(author.name))
         except discord.Forbidden:
-            print(f'!role: Forbidden: {author.name}.remove_role( {target_name} )')
-            return role.permission_failure_message(self.name, target_name)
+            print(f'!role: Forbidden: {author.name}.remove_role( {target_role.name} )')
+            return role.permission_failure_message(self.name, target_role.name)
         except discord.HTTPException:
-            print(f'!role: Failed API call: {author.name}.remove_role( {target_name} )')
-            return role.permission_failure_message(self.name, target_name)
+            print(f'!role: Failed API call: {author.name}.remove_role( {target_role.name} )')
+            return role.permission_failure_message(self.name, target_role.name)
         finally:
-            return CommandOutput().set_text(f'{author.name} successfully left `@{target_name}`')
+            return CommandOutput().set_text(f'{author.name} successfully left `@{target_role.name}`')

--- a/src/commands/role/list.py
+++ b/src/commands/role/list.py
@@ -43,7 +43,7 @@ class List(Command):
             if target_role is None:
                 return role.action_failure_message(self.name, target_name, f'The role `@{target_name}` was not found!')
             if not target_role.members:
-                return CommandOutput().set_text(f'Role `@{target_name}` has no members!')
+                return CommandOutput().set_text(f'Role `@{target_role.name}` has no members!')
 
             member_names = []
             for member in target_role.members:
@@ -53,6 +53,6 @@ class List(Command):
                     member_names.append(member.name)
 
             member_names.sort()
-            member_names.insert(0, f'Members of `@{target_name}`:')
+            member_names.insert(0, f'Members of `@{target_role.name}`:')
 
             return CommandOutput(content='\n- '.join(member_names))


### PR DESCRIPTION
Previously, the `!role` command would only allow users to input the name of a role, and would error if the user attempted to @ the role. This was inconvenient, because a lot of users use @ mentions for their autocomplete. Now, users can choose to @ the role with which they want to interact, or not! Either will work :)

Also, refactored any uses of `target_name` variables after a `discord.Role` object would have been resolved, so that the name of the role output to the user will always be canonical, and not a long integer ID if it was an @ mention.

Resolves #56.
