### PR TITLE
Move Twitter integration to separate module

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ If you are hosting yourself, you will need to create a file in the root director
 Usage of the bot is as follows:
 
 ```
-usage: main.py [-h] [--discord-api-token DISCORD_API_TOKEN] [--twitter-api-tokens TWITTER_API_TOKENS]
+usage: main.py [-h] [--discord-api-token DISCORD_API_TOKEN] [--twitter-api-tokens TWITTER_API_TOKENS] [--no-twitter] [--nodb] [--database-uri DATABASE_URI]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -15,6 +15,10 @@ optional arguments:
                         Path to the file containing the Discord API token
   --twitter-api-tokens TWITTER_API_TOKENS
                         Path to the file containing the Twitter API tokens, in JSON format.
+  --no-twitter          Disable Twitter integration
+  --nodb                Disable the database connection, and all features which require it.
+  --database-uri DATABASE_URI
+                        URI of the MongoDB database server
 ```
 
 Current commands that can be used in Discord:

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -7,6 +7,9 @@ discord_api_token: pathlib.Path
 # Path to the JSON file containing the Twitter API tokens
 twitter_api_tokens: pathlib.Path
 
+# Flag which tells if Twitter integration is enabled
+twitter_enabled: bool
+
 # Flag which tells if a database connection is enabled
 database_enabled: bool
 # MongoDB URI
@@ -26,6 +29,13 @@ def populate_config_from_command_line():
                         default="twitter_api_tokens.json",
                         type=pathlib.Path)
 
+    # Twitter Integration
+    parser.add_argument("--no-twitter",
+                        help="Disable Twitter integration",
+                        dest="twitter_enabled",
+                        action="store_false")
+    parser.set_defaults(twitter_enabled=True)
+
     # Database Configuration
     parser.add_argument("--nodb",
                         help="Disable the database connection, and all features which require it.",
@@ -44,6 +54,9 @@ def populate_config_from_command_line():
     global twitter_api_tokens
     discord_api_token = args.discord_api_token
     twitter_api_tokens = args.twitter_api_tokens
+
+    global twitter_enabled
+    twitter_enabled = args.twitter_enabled
 
     global database_enabled
     global database_uri

--- a/src/integrations/twitter.py
+++ b/src/integrations/twitter.py
@@ -1,0 +1,103 @@
+"""
+This is a module for managing our integration with Twitter. It owns all metadata related to Twitter, and the only state
+it maintains is whether or not the API has been initialized.
+
+All functions that make any network communication, except for init, should be asynchronous and stateless.
+"""
+import asyncio
+import json
+import re
+import pathlib
+
+import discord
+import tweepy
+
+from lib import constants
+
+# Regular expression that describes the pattern of a Tweet URL
+twitter_url_pattern = re.compile(r'https://twitter\.com/([0-9a-zA-Z_]+|i/web)/status/[0-9]+(\?s=\d+)?')
+
+# Twitter API handle
+twitter_api: tweepy.API
+
+
+def init(api_token_path: pathlib.Path):
+    """
+    Authenticates to the Twitter API. This function must be synchronous, as any further interaction with Twitter
+    depends on this function executing and returning successfully.
+    :param api_token_path: The path to the file containing the Twitter API tokens, in JSON format
+    """
+    global twitter_api
+    with open(api_token_path) as twitter_api_tokens:
+        twitter_tokens = json.load(twitter_api_tokens)
+    twitter_api = tweepy.API(tweepy.AppAuthHandler(twitter_tokens['consumer_key'], twitter_tokens['consumer_secret']))
+
+
+def get_twitter_api() -> tweepy.API:
+    """
+    Utility function for acquiring the module's API object, as to skip the null-checking
+    :raises ValueError: If init() has not yet been called, making _twitter_api None
+    :return: _twitter_api, if it has been initialized.
+    """
+    if twitter_api is None:
+        raise ValueError("Twitter integration module has not yet been initialized.")
+    return twitter_api
+
+
+def get_twitter_url_from_message_content(content: str) -> str:
+    """
+    Loops through each "word" in conetnt, compares the word to a regex
+    and returns the "word" in the message that matches the twitter URL regex
+    :param content: message that was sent in discord
+    """
+    match = twitter_url_pattern.search(content)
+    if match:
+        return match[0]
+    else:
+        return ""
+
+
+async def get_quote_tweet_urls(tweet_info: tweepy.models.Status) -> str:
+    """
+    Gets URLs of quoteted tweets (nested up to max 3)
+    :param tweet_info: information of tweet
+    :return: URL of media/quote tweet(s)
+    """
+    tweets = "quoted tweet(s): "
+    for _ in range(3):
+        tweets += f"\nhttps://twitter.com/{tweet_info.quoted_status.author.screen_name}" \
+                  f"/status/{tweet_info.quoted_status.id_str}"
+        tweet_info = get_twitter_api().get_status(tweet_info.quoted_status.id)
+        if not tweet_info.is_quote_status:
+            break
+    return tweets
+
+
+async def process_message_for_interaction(message: discord.Message):
+    """
+    Processes non-command content of a message to determine if a message contains Tweet information and requires
+    interaction from MemeBot. Note that this will still affect command messages, but the content is not processed
+    as a command by this function.
+    :param message: The message to process
+    """
+    # Iterate through the message sent, and check if the message contained
+    # a "word" that was a twitter URL to a status.
+    twitter_url = get_twitter_url_from_message_content(message.content)
+    if twitter_url:
+        # Because a twitter URL to a status is oftentimes as follows:
+        # https://twitter.com/USER/status/xxxxxxxxxxxxxxxxxxx?s=yy
+        # We need to split up the URL by the "/", and then split it up again by the "?" in order to get
+        # the ID of the tweet being linked
+        tweet_id = twitter_url.split("/")[-1].split("?")[0]
+        tweet_info = get_twitter_api().get_status(tweet_id)
+        tweet_media = tweet_info.extended_entities['media'] if 'media' in tweet_info.entities else []
+
+        # React with a numeric emoji to Tweets containing multiple images
+        if len(tweet_media) > 1:
+            emoji = ":" + str(len(tweet_media)) + ":"
+            asyncio.create_task(message.add_reaction(constants.EMOJI_MAP[emoji]))
+
+        # Post
+        if tweet_info.is_quote_status:
+            quote_tweet_urls = await get_quote_tweet_urls(tweet_info)
+            asyncio.create_task(message.channel.send(quote_tweet_urls))

--- a/src/integrations/twitter.py
+++ b/src/integrations/twitter.py
@@ -23,8 +23,8 @@ twitter_api: tweepy.API
 
 def init(api_token_path: pathlib.Path):
     """
-    Authenticates to the Twitter API. This function must be synchronous, as any further interaction with Twitter
-    depends on this function executing and returning successfully.
+    Authenticates to the Twitter API. This function is left synchronous, as any further interaction with Twitter
+    depends on this function executing and returning successfully, and it should only be run once at startup.
     :param api_token_path: The path to the file containing the Twitter API tokens, in JSON format
     """
     global twitter_api

--- a/src/memebot.py
+++ b/src/memebot.py
@@ -37,7 +37,8 @@ class MemeBot(discord.Client):
         if message.author != self.user:
             await commands.execution.execute_if_command(message)
 
-        asyncio.create_task(twitter.process_message_for_interaction(message))
+        if config.twitter_enabled:
+            asyncio.create_task(twitter.process_message_for_interaction(message))
 
         
 client: discord.Client = MemeBot()

--- a/src/memebot.py
+++ b/src/memebot.py
@@ -1,13 +1,11 @@
-import json
-import re
+import asyncio
 
 import discord
-import tweepy
 
 import commands
 import config
 import db
-from lib import constants
+from integrations import twitter
 
 
 class MemeBot(discord.Client):
@@ -17,16 +15,8 @@ class MemeBot(discord.Client):
 
     def __init__(self, **args):
         super().__init__(**args, intents=discord.Intents().all())
-
-        with open(config.twitter_api_tokens) as twitter_api_tokens:
-            twitter_tokens = json.load(twitter_api_tokens)
-
-        self.twitter_api = tweepy.API(
-            tweepy.AppAuthHandler(twitter_tokens['consumer_key'], twitter_tokens['consumer_secret']))
-
-        self.twitter_url_pattern = re.compile(
-            r'.*(https://twitter\.com/([0-9a-zA-Z_]+|i/web)/status/[0-9]+(\?s=\d+)?).*')
-
+        if config.twitter_enabled:
+            twitter.init(config.twitter_api_tokens)
         db.test()
 
     async def on_ready(self) -> None:
@@ -49,53 +39,7 @@ class MemeBot(discord.Client):
         else:
             await commands.execution.execute_if_command(message)
 
-        # Iterate through the message sent, and check if the message conatined
-        # a "word" that was a twitter URL to a status.
-        twitter_url = self.get_twitter_url_from_message(message.content)
-        if twitter_url:
-
-            """Because a twitter URL to a status is oftentimes as follows:
-            https://twitter.com/USER/status/xxxxxxxxxxxxxxxxxxx?s=yy
-            We need to split up the URL by the "/", and then split it up
-            again by the "?" in order to get the ID of the tweet being
-            linked"""
-            tweet_id = twitter_url.split("/")[-1].split("?")[0]
-            tweet_info = self.twitter_api.get_status(tweet_id)
-            tweet_media = tweet_info.extended_entities['media'] if 'media' in tweet_info.entities else []
-
-            if len(tweet_media) > 1:
-                emoji = ":" + str(len(tweet_media)) + ":"
-                await message.add_reaction(constants.EMOJI_MAP[emoji])
-
-            if tweet_info.is_quote_status:
-                quote_tweet_urls = self.get_quote_tweet_urls(tweet_info)
-                await message.channel.send(quote_tweet_urls)
-
-    def get_twitter_url_from_message(self, content: str) -> str:
-        """
-        Loops through each "word" in conetnt, compares the word to a regex
-        and returns the "word" in the message that matches the twitter URL regex
-        :param content: message that was sent in discord
-        """
-        match = self.twitter_url_pattern.match(content)
-        if match:
-            return match.groups()[0]
-        else:
-            return ""
-
-    def get_quote_tweet_urls(self, tweet_info: tweepy.models.Status) -> str:
-        """
-        Gets URLs of quoteted tweets (nested up to max 3)
-        :param tweet_info: information of tweet
-        :return: URL of media/quote tweet(s)
-        """
-        tweets = "quoted tweet(s): "
-        for _ in range(3):
-            tweets += "\nhttps://twitter.com/" + tweet_info.quoted_status.author.screen_name + "/status/" + tweet_info.quoted_status.id_str
-            tweet_info = self.twitter_api.get_status(tweet_info.quoted_status.id)
-            if not tweet_info.is_quote_status:
-                break
-        return tweets
+        asyncio.create_task(twitter.process_message_for_interaction(message))
 
 
 client: discord.Client = MemeBot()


### PR DESCRIPTION
All of MemeBot's Twitter integration has been moved to a [separate module](src/integrations/twitter.py), and have been made asynchronous and stateless. The only state managed by the Twitter module is whether or not MemeBot has authenticated to the Twitter API. This is done by MemeBot using the `twitter.init` function. If MemeBot attempts to make any API calls before `init` is called, the functions which make those calls will throw.

Fixes #64.
