### PR TITLE
Fix container DNS speed issues

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -17,6 +17,8 @@ services:
       PYTHONUNBUFFERED: 1
     networks:
       default:
+    dns:
+      - 172.19.0.1
   db:
     container_name: memebot-db
     image: mongo:4.4.4-bionic
@@ -26,6 +28,8 @@ services:
       - ../src/config/mongod.yaml:/etc/mongo/mongod.yaml:ro
     networks:
       default:
+    dns:
+      - 172.19.0.1
 
 networks:
   default:


### PR DESCRIPTION
Explicitly sets the containers' DNS servers as the Docker network's router, which will forward to the local relay. For some reason, not specifying this would drastically slow down DNS lookups even though the DNS server would still resolve to the same device.
