### PR TITLE
Create logging subsystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ If you are hosting yourself, you will need to create a file in the root director
 Usage of the bot is as follows:
 
 ```
-usage: main.py [-h] [--discord-api-token DISCORD_API_TOKEN] [--twitter-api-tokens TWITTER_API_TOKENS] [--log-level LOG_LEVEL] [--log-location LOG_LOCATION] [--no-twitter] [--nodb] [--database-uri DATABASE_URI]
+usage: main.py [-h] [--discord-api-token DISCORD_API_TOKEN] [--twitter-api-tokens TWITTER_API_TOKENS] [--log-level {DEBUG,INFO,WARNING,ERROR,CRITICAL} | -v] [--log-location {stdout,stderr,syslog,/path/to/file}] [--no-twitter] [--nodb] [--database-uri DATABASE_URI]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -15,10 +15,11 @@ optional arguments:
                         Path to the file containing the Discord API token
   --twitter-api-tokens TWITTER_API_TOKENS
                         Path to the file containing the Twitter API tokens, in JSON format.
-  --log-level LOG_LEVEL
-                        Set the log level for MemeBot.
-  --log-location LOG_LOCATION
-                        Set the location for MemeBot's log (stdout, stderr, syslog, /path/to/file)
+  --log-level {DEBUG,INFO,WARNING,ERROR,CRITICAL}
+                        Set logging level
+  -v, --verbose         Use verbose logging. Equivalent to --log-level DEBUG
+  --log-location {stdout,stderr,syslog,/path/to/file}
+                        Set the location for MemeBot's log
   --no-twitter          Disable Twitter integration
   --nodb                Disable the database connection, and all features which require it.
   --database-uri DATABASE_URI

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ If you are hosting yourself, you will need to create a file in the root director
 Usage of the bot is as follows:
 
 ```
-usage: main.py [-h] [--discord-api-token DISCORD_API_TOKEN] [--twitter-api-tokens TWITTER_API_TOKENS] [--no-twitter] [--nodb] [--database-uri DATABASE_URI]
+usage: main.py [-h] [--discord-api-token DISCORD_API_TOKEN] [--twitter-api-tokens TWITTER_API_TOKENS] [--log-level LOG_LEVEL] [--log-location LOG_LOCATION] [--no-twitter] [--nodb] [--database-uri DATABASE_URI]
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -15,6 +15,10 @@ optional arguments:
                         Path to the file containing the Discord API token
   --twitter-api-tokens TWITTER_API_TOKENS
                         Path to the file containing the Twitter API tokens, in JSON format.
+  --log-level LOG_LEVEL
+                        Set the log level for MemeBot.
+  --log-location LOG_LOCATION
+                        Set the location for MemeBot's log (stdout, stderr, syslog, /path/to/file)
   --no-twitter          Disable Twitter integration
   --nodb                Disable the database connection, and all features which require it.
   --database-uri DATABASE_URI

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -1,11 +1,19 @@
 import argparse
+import logging
 import pathlib
 import urllib.parse
+
+from config import validators
 
 # Path to the file containing the Discord API token
 discord_api_token: pathlib.Path
 # Path to the JSON file containing the Twitter API tokens
 twitter_api_tokens: pathlib.Path
+
+# The logging level for MemeBot
+log_level: int
+# The location for MemeBot's log
+log_location: logging.Handler
 
 # Flag which tells if Twitter integration is enabled
 twitter_enabled: bool
@@ -28,6 +36,16 @@ def populate_config_from_command_line():
                         help="Path to the file containing the Twitter API tokens, in JSON format.",
                         default="twitter_api_tokens.json",
                         type=pathlib.Path)
+
+    # Logging Configuration
+    parser.add_argument("--log-level",
+                        help="Set the log level for MemeBot.",
+                        default=logging.INFO,
+                        type=validators.validate_log_level)
+    parser.add_argument("--log-location",
+                        help="Set the location for MemeBot's log (stdout, stderr, syslog, /path/to/file)",
+                        default="stdout",
+                        type=validators.validate_log_location)
 
     # Twitter Integration
     parser.add_argument("--no-twitter",
@@ -54,6 +72,11 @@ def populate_config_from_command_line():
     global twitter_api_tokens
     discord_api_token = args.discord_api_token
     twitter_api_tokens = args.twitter_api_tokens
+
+    global log_level
+    global log_location
+    log_level = args.log_level
+    log_location = args.log_location
 
     global twitter_enabled
     twitter_enabled = args.twitter_enabled

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -38,13 +38,25 @@ def populate_config_from_command_line():
                         type=pathlib.Path)
 
     # Logging Configuration
-    parser.add_argument("--log-level",
-                        help="Set the log level for MemeBot.",
-                        default=logging.INFO,
-                        type=validators.validate_log_level)
+    logging_verbosity_group = parser.add_mutually_exclusive_group()
+    # Accept all log levels recognized by the logging library except NOTSET
+    logging_verbosity_group.add_argument("--log-level",
+                                         help=f"Set logging level",
+                                         choices=[logging.getLevelName(level) for level in (
+                                             logging.DEBUG, logging.INFO, logging.WARN, logging.ERROR,
+                                             logging.CRITICAL)],
+                                         default=logging.getLevelName(logging.INFO),
+                                         type=str)
+    logging_verbosity_group.add_argument("-v",
+                                         "--verbose",
+                                         help="Use verbose logging. Equivalent to --log-level DEBUG",
+                                         dest="log_level",
+                                         action="store_const",
+                                         const=logging.getLevelName(logging.DEBUG))
     parser.add_argument("--log-location",
-                        help="Set the location for MemeBot's log (stdout, stderr, syslog, /path/to/file)",
+                        help="Set the location for MemeBot's log",
                         default="stdout",
+                        metavar="{stdout,stderr,syslog,/path/to/file}",
                         type=validators.validate_log_location)
 
     # Twitter Integration

--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -11,7 +11,7 @@ discord_api_token: pathlib.Path
 twitter_api_tokens: pathlib.Path
 
 # The logging level for MemeBot
-log_level: int
+log_level: str
 # The location for MemeBot's log
 log_location: logging.Handler
 

--- a/src/config/validators.py
+++ b/src/config/validators.py
@@ -1,0 +1,21 @@
+"""
+Functions that will validate string input from the command line and convert them into appropriate data for use
+by the config module.
+"""
+import collections
+import logging
+import logging.handlers
+import sys
+
+
+# Logging validators
+def validate_log_level(level: str) -> int:
+    return logging._checkLevel(level)
+
+
+def validate_log_location(location: str) -> logging.Handler:
+    return collections.defaultdict((lambda: logging.FileHandler(location)), **{
+        "stdout": logging.StreamHandler(sys.stdout),
+        "stderr": logging.StreamHandler(sys.stderr),
+        "syslog": logging.handlers.SysLogHandler(),
+    })[location]

--- a/src/config/validators.py
+++ b/src/config/validators.py
@@ -9,10 +9,6 @@ import sys
 
 
 # Logging validators
-def validate_log_level(level: str) -> int:
-    return logging._checkLevel(level)
-
-
 def validate_log_location(location: str) -> logging.Handler:
     return collections.defaultdict((lambda: logging.FileHandler(location)), **{
         "stdout": logging.StreamHandler(sys.stdout),

--- a/src/log/__init__.py
+++ b/src/log/__init__.py
@@ -1,0 +1,28 @@
+import atexit
+import contextlib
+import logging
+
+import config
+from log import formatter, logger
+
+config.log_location.setFormatter(formatter.MemeBotLogFormatter())
+logging.setLoggerClass(logger.MemeBotLogger)
+
+# Redirect all stdout to a logger, as some packages in the stdlib still use print for debug messages
+stdout_logger = logging.getLogger("stdout")
+contextlib.redirect_stdout(stdout_logger).__enter__()
+
+# Ensure the handler is properly flushed when MemeBot is killed
+atexit.register(logging.shutdown)
+
+
+def set_third_party_logging():
+    """
+    Enable logging on third-party packages that can't be overwritten with MemeBotLogger
+    """
+    # Tweepy does not use a unified logger, so the best we can do is enable its debug mode.
+    import asyncio
+    import tweepy
+    if config.log_level == logging.DEBUG:
+        asyncio.get_event_loop().set_debug(True)
+        tweepy.debug()

--- a/src/log/__init__.py
+++ b/src/log/__init__.py
@@ -1,12 +1,16 @@
 import atexit
 import contextlib
 import logging
+from typing import Callable, Iterable
 
 import config
-from log import formatter, logger
+from . import formatter, logger
 
 config.log_location.setFormatter(formatter.MemeBotLogFormatter())
 logging.setLoggerClass(logger.MemeBotLogger)
+
+# We use a project-wide logger because of how we shim metadata into log statements
+memebot_logger = logging.getLogger("memebot")
 
 # Redirect all stdout to a logger, as some packages in the stdlib still use print for debug messages
 stdout_logger = logging.getLogger("stdout")
@@ -23,6 +27,28 @@ def set_third_party_logging():
     # Tweepy does not use a unified logger, so the best we can do is enable its debug mode.
     import asyncio
     import tweepy
-    if config.log_level == logging.DEBUG:
+    if config.log_level == logging.getLevelName(logging.DEBUG):
         asyncio.get_event_loop().set_debug(True)
         tweepy.debug()
+
+
+def log_all(logging_func: Callable, messages: Iterable[str], *args, **kwargs):
+    """
+    Create a multiple log statements for a collection of messages.
+    :param logging_func: The function to use for logging i.e. self.debug, self.info, etc.
+    :param messages: The list of messages to log
+    :param args: Additional args; passed straight to logging_func
+    :param kwargs: Additional kwargs; passed straight to logging_func
+    """
+    for line in messages:
+        logging_func(line, *args, **kwargs)
+
+
+# Forward memebot_logger's logging methods as module-level functions
+debug = memebot_logger.debug
+info = memebot_logger.info
+warning = memebot_logger.warning
+error = memebot_logger.error
+critical = memebot_logger.critical
+log = memebot_logger.log
+exception = memebot_logger.exception

--- a/src/log/formatter.py
+++ b/src/log/formatter.py
@@ -9,9 +9,13 @@ class MemeBotLogFormatter(logging.Formatter):
 
     def __init__(self):
         super().__init__(
-            fmt="{asctime}\t{levelname}\t{name}: {message}",
+            # This format will print as such:
+            # [YYYY-MM-DD HH:MM:SS.uuu   LOGLEVEL    log.statement.call.site:line] I am a log message!
+            fmt="[{asctime}\t{levelname}\t{_callsite}:{_lineno}]\t{message}",
             style='{'
         )
+        # Have the milliseconds in timestamps separated by '.' instead of ','
+        self.default_msec_format = self.default_msec_format.replace(',', '.')
 
     def formatException(self, ex: Any) -> str:
         return repr(super().formatException(ex))

--- a/src/log/formatter.py
+++ b/src/log/formatter.py
@@ -1,0 +1,23 @@
+import logging
+from typing import Any
+
+
+class MemeBotLogFormatter(logging.Formatter):
+    """
+    Defines the log formatting for MemeBot
+    """
+
+    def __init__(self):
+        super().__init__(
+            fmt="{asctime}\t{levelname}\t{name}: {message}",
+            style='{'
+        )
+
+    def formatException(self, ex: Any) -> str:
+        return repr(super().formatException(ex))
+
+    def format(self, record: logging.LogRecord) -> str:
+        result = super().format(record)
+        if record.exc_text:
+            result = result.replace("\n", "")
+        return result

--- a/src/log/logger.py
+++ b/src/log/logger.py
@@ -1,0 +1,49 @@
+import inspect
+import io
+import logging
+import os
+import threading
+
+import config
+
+
+class MemeBotLogger(logging.Logger, io.IOBase):
+    """
+    Defines a logging class that can be used to define a consistent logging style accross all modules
+    """
+
+    def __init__(self, name: str):
+        super().__init__(name)
+        self.setLevel(config.log_level)
+        self.propagate = False
+        self.lock = threading.Lock()
+        super().addHandler(config.log_location)
+
+    def addHandler(self, hdlr: logging.Handler):
+        # We want to avoid external packages overwriting our custom handler
+        return
+
+    def write(self, msg: str):
+        """
+        This method is purely for stdout redirection, as contextlib requires a file-like object for redirection.
+        This method also attempts to differentiate calls to print made within the memebot repo and print them as
+        info instead of debug.
+        """
+        with self.lock:
+            # Capture the stack here, on a line without the string "print(" in it
+            stack = inspect.stack()
+            # Find the stack frame which (hopefully) contains the call to print
+            print_frame = next((frame for frame in stack if "print(" in frame.code_context[0]), None)
+            namespace = inspect.getmodulename(print_frame.filename) if print_frame is not None else "stdout"
+            old_name = self.name
+            self.name = namespace
+            if msg and not msg.isspace():
+                if print_frame is not None and not print_frame.filename.startswith(os.getcwd()):
+                    # We want to use debug logging for any non-memebot modules using print
+                    for line in msg.splitlines():
+                        self.debug(line)
+                else:
+                    # If someone puts a print statement inside memebot code, output it regardless of log level
+                    for line in msg.splitlines():
+                        self.info(line)
+            self.name = old_name

--- a/src/log/logger.py
+++ b/src/log/logger.py
@@ -1,10 +1,27 @@
+import functools
 import inspect
 import io
 import logging
 import os
-import threading
+import sys
+from typing import Union
 
 import config
+import log
+
+memebot_context = os.getcwd()
+
+
+@functools.cache
+def get_module_name_from_path(path: str) -> str:
+    """
+    Returns the module name for a given file as it would appear in an import statement
+    :param path: The path to the python file
+    :return: Essentially, the output of __name__ if it were referenced in the given module.
+    If the module cannot be found, returns an empty string
+    """
+    target = next((mod for mod in sys.modules.values() if hasattr(mod, "__file__") and mod.__file__ == path), None)
+    return target.__name__ if target else ""
 
 
 class MemeBotLogger(logging.Logger, io.IOBase):
@@ -12,16 +29,34 @@ class MemeBotLogger(logging.Logger, io.IOBase):
     Defines a logging class that can be used to define a consistent logging style accross all modules
     """
 
-    def __init__(self, name: str):
-        super().__init__(name)
-        self.setLevel(config.log_level)
+    def __init__(self, name: str, level: Union[int, str] = config.log_level):
+        super().__init__(name, level)
         self.propagate = False
-        self.lock = threading.Lock()
         super().addHandler(config.log_location)
 
-    def addHandler(self, hdlr: logging.Handler):
+    def addHandler(self, _: logging.Handler):
         # We want to avoid external packages overwriting our custom handler
         return
+
+    def _log(self, level, msg, args, exc_info=None, extra=None, stack_info=False, stacklevel=1):
+        """
+        Apply some hooks to the internal logging function.
+        """
+        try:
+            file_name, line_number, _, _ = self.findCaller(stack_info, stacklevel)
+        except ValueError:
+            # If we can't extract MemeBot logging metadata, just do the best we can
+            super()._log(logging.ERROR, "Could not determine log statement callsite.", (),
+                         extra={'_callsite': __name__, "_lineno": inspect.getframeinfo(inspect.currentframe()).lineno})
+            super()._log(level, msg, args, exc_info, extra, stack_info, stacklevel)
+            return
+        # Log the line number on which the log statement was made
+        memebot_lineno = f"{line_number}:"
+        callsite = get_module_name_from_path(file_name)
+        updated_extra = {'_lineno': line_number, '_callsite': callsite if callsite else self.name}
+        if extra is not None:
+            updated_extra.update(extra)
+        super()._log(level, msg, args, exc_info, updated_extra, stack_info, stacklevel)
 
     def write(self, msg: str):
         """
@@ -29,22 +64,22 @@ class MemeBotLogger(logging.Logger, io.IOBase):
         This method also attempts to differentiate calls to print made within the memebot repo and print them as
         info instead of debug.
         """
-        with self.lock:
-            if msg and not msg.isspace():
-                # Capture the stack here, on a line without the string "print(" in it
-                stack = inspect.stack()
-                # Find the stack frame which (hopefully) contains the call to print
-                print_frame = next((frame for frame in stack if "print(" in frame.code_context[0]), None)
-                namespace = inspect.getmodulename(print_frame.filename) if print_frame is not None else "stdout"
-                old_name = self.name
-                self.name = namespace
-                if print_frame is not None:
-                    if not print_frame.filename.startswith(os.getcwd()):
-                        # We want to use debug logging for any non-memebot modules using print
-                        for line in msg.splitlines():
-                            self.debug(line)
-                    else:
-                        # If someone puts a print statement inside memebot code, output it regardless of log level
-                        for line in msg.splitlines():
-                            self.info(line)
-                self.name = old_name
+        if msg and not msg.isspace():
+            # Capture the stack here, on a line without the string "print(" in it
+            stack = inspect.stack()
+            # Find the stack frame which (hopefully) contains the call to print
+            print_frame = next((frame for frame in stack if "print(" in frame.code_context[0]), None)
+            if print_frame is not None:
+                module_name = get_module_name_from_path(print_frame.filename)
+                log_extra = {"_callsite": module_name, "_lineno": print_frame.lineno}
+                if print_frame.filename.startswith(memebot_context):
+                    # If someone puts a print statement inside memebot code, output it regardless of log level
+                    log.log_all(self.info, msg.splitlines(), extra=log_extra)
+                else:
+                    # We want to use debug logging for any non-memebot modules using print
+                    log.log_all(self.debug, msg.splitlines(), extra=log_extra)
+            else:
+                self.error(
+                    f"Attempted to format a print statement, but couldn't figure out where the print came from",
+                    stack_info=True)
+                log.log_all(self.info, msg.splitlines())

--- a/src/log/logger.py
+++ b/src/log/logger.py
@@ -51,7 +51,6 @@ class MemeBotLogger(logging.Logger, io.IOBase):
             super()._log(level, msg, args, exc_info, extra, stack_info, stacklevel)
             return
         # Log the line number on which the log statement was made
-        memebot_lineno = f"{line_number}:"
         callsite = get_module_name_from_path(file_name)
         updated_extra = {'_lineno': line_number, '_callsite': callsite if callsite else self.name}
         if extra is not None:

--- a/src/log/logger.py
+++ b/src/log/logger.py
@@ -30,20 +30,21 @@ class MemeBotLogger(logging.Logger, io.IOBase):
         info instead of debug.
         """
         with self.lock:
-            # Capture the stack here, on a line without the string "print(" in it
-            stack = inspect.stack()
-            # Find the stack frame which (hopefully) contains the call to print
-            print_frame = next((frame for frame in stack if "print(" in frame.code_context[0]), None)
-            namespace = inspect.getmodulename(print_frame.filename) if print_frame is not None else "stdout"
-            old_name = self.name
-            self.name = namespace
             if msg and not msg.isspace():
-                if print_frame is not None and not print_frame.filename.startswith(os.getcwd()):
-                    # We want to use debug logging for any non-memebot modules using print
-                    for line in msg.splitlines():
-                        self.debug(line)
-                else:
-                    # If someone puts a print statement inside memebot code, output it regardless of log level
-                    for line in msg.splitlines():
-                        self.info(line)
-            self.name = old_name
+                # Capture the stack here, on a line without the string "print(" in it
+                stack = inspect.stack()
+                # Find the stack frame which (hopefully) contains the call to print
+                print_frame = next((frame for frame in stack if "print(" in frame.code_context[0]), None)
+                namespace = inspect.getmodulename(print_frame.filename) if print_frame is not None else "stdout"
+                old_name = self.name
+                self.name = namespace
+                if print_frame is not None:
+                    if not print_frame.filename.startswith(os.getcwd()):
+                        # We want to use debug logging for any non-memebot modules using print
+                        for line in msg.splitlines():
+                            self.debug(line)
+                    else:
+                        # If someone puts a print statement inside memebot code, output it regardless of log level
+                        for line in msg.splitlines():
+                            self.info(line)
+                self.name = old_name

--- a/src/main.py
+++ b/src/main.py
@@ -1,3 +1,6 @@
+# In order to ensure consistent logging, log must always be the first thing imported by the main module
+import log
+
 import sys
 
 import config
@@ -9,6 +12,7 @@ def main() -> int:
     Main function, initializes MemeBot and then loops
     :return: Exit status of discord.Client.run()
     """
+    log.set_third_party_logging()
     client = memebot.client
 
     # !! DO NOT HARDCODE THE TOKEN !!

--- a/src/memebot.py
+++ b/src/memebot.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 
 import discord
 
@@ -6,6 +7,8 @@ import commands
 import config
 import db
 from integrations import twitter
+
+logger = logging.getLogger(__name__)
 
 
 class MemeBot(discord.Client):
@@ -19,12 +22,11 @@ class MemeBot(discord.Client):
             twitter.init(config.twitter_api_tokens)
         db.test()
 
-    async def on_ready(self) -> None:
+    async def on_ready(self):
         """
         Determines what the bot does as soon as it is logged into discord
-        :return: None
         """
-        print(f'Logged in as {self.user}')
+        logger.info(f'Logged in as {self.user}')
 
     async def on_message(self, message: discord.Message) -> None:
         """
@@ -40,5 +42,5 @@ class MemeBot(discord.Client):
         if config.twitter_enabled:
             asyncio.create_task(twitter.process_message_for_interaction(message))
 
-        
+
 client: discord.Client = MemeBot()

--- a/src/memebot.py
+++ b/src/memebot.py
@@ -6,6 +6,7 @@ import discord
 import commands
 import config
 import db
+import log
 from integrations import twitter
 
 logger = logging.getLogger(__name__)
@@ -26,7 +27,7 @@ class MemeBot(discord.Client):
         """
         Determines what the bot does as soon as it is logged into discord
         """
-        logger.info(f'Logged in as {self.user}')
+        log.info(f'Logged in as {self.user}')
 
     async def on_message(self, message: discord.Message) -> None:
         """


### PR DESCRIPTION
I have created a basic logging system for MemeBot based on python's own `logging` package. I have set up a custom formatter and all external modules will use it. We also redirect stdout to a MemeBot logger so any external libraries using print will be formatted as well. Any print statements used from within MemeBot will be logged at the INFO level, where any calls not written by us will be logged as DEBUG. This was done so that we can use print debugging without having to raise the log level.

As of right now, logging has not been fully integrated into the codebase. This patch was already pretty large, and I figured it would be better to have the foundation of the logging system merged before more logging statements were added.
