### PR TITLE
Use `functools.lru_cache` instead of `functools.cache`

### DIFF
--- a/src/log/logger.py
+++ b/src/log/logger.py
@@ -12,7 +12,7 @@ import log
 memebot_context = os.getcwd()
 
 
-@functools.cache
+@functools.lru_cache
 def get_module_name_from_path(path: str) -> str:
     """
     Returns the module name for a given file as it would appear in an import statement


### PR DESCRIPTION
Swapped our use of `functools.cache` to `functools.lru_cache`. I was led to believe that using the `cache` wrapper would be fine because it was implemented in python 3.8, but for some reason it doesn't exist in the Docker image.