### PR TITLE
Extend `!help` command to accept names of other commands as arguments

### DIFF
--- a/src/commands/command.py
+++ b/src/commands/command.py
@@ -17,7 +17,7 @@ class CommandMeta(type):
         if cls.__name__ == "Command":
             cls.parent: None
         else:
-            cls.parent: Command = Command("default", "")
+            cls.parent: Command = Command(name="default", description="", long_description="")
         cls.subcommands: List[Command] = []
 
 
@@ -28,16 +28,20 @@ class Command(metaclass=CommandMeta):
 
         - name: this is the activator for the command, i.e. the thing used like `!name`
         - description: this is a brief description of the command, used by !help
+        - long_description: this is a longer description of the command which gives the user more context about its use
     """
 
     @abstractmethod
-    def __init__(self, name: str = None, description: str = None, example_args: str = ""):
+    def __init__(self, name: str = None, description: str = None, long_description: str = None, example_args: str = ""):
         """
         Default constructor. Ensures that all pieces of command are properly implemented.
-        :param name The name of the command, which is the "activation string" when typed by a user in Discord.
-        :param description A _very_ brief description of the command to be printed by the !help command.
-        :param example_args An example of arguments to be used with this command, to be printed as a usage message.
-        :raise ValueError if a required attribute is not set or is invalid.
+        Default values are used for required arguments so that subclasses are able to override this method without
+        requiring the arguments.
+        :param name: The name of the command, which is the "activation string" when typed by a user in Discord.
+        :param description: A _very_ brief description of the command to be printed by the !help command.
+        :param long_description: a long description with more context about the command's use
+        :param example_args: An example of arguments to be used with this command, to be printed as a usage message.
+        :raise ValueError: if a required attribute is not set or is invalid.
         """
         if name is None:
             raise ValueError(f"Every command needs to have a name! ({type(self).__name__})")
@@ -46,20 +50,15 @@ class Command(metaclass=CommandMeta):
         self.name: str = name
         if description is None:
             raise ValueError(f"Every command needs to have a description! ({type(self).__name__})")
+        if long_description is None:
+            raise ValueError(f"Every command needs to have a long description! ({type(self).__name__}")
         self.description: str = description
+        self.long_description = long_description
         self.example_args: str = example_args
         self.requires_database: bool = False
 
     def __repr__(self) -> str:
         return f"Command: {type(self).__name__}(name={self.name} description={self.description})"
-
-    @abstractmethod
-    def long_description(self) -> CommandOutput:
-        """
-        Returns a CommandOutput describing this particular command in detail.
-        :returns A long description of the command, which should be sent to the server.
-        """
-        raise NotImplementedError()
 
     def help_text(self) -> CommandOutput:
         """
@@ -75,7 +74,7 @@ class Command(metaclass=CommandMeta):
         cmd_preamble = ' '.join(parent_list)
         if len(cmd_preamble) > 0:
             cmd_preamble += ' '
-        output = self.long_description().append_line(
+        output = CommandOutput(content=self.long_description).append_line(
             f"**`!{cmd_preamble}{self.name}" + (f" {self.example_args}`**" if len(self.example_args) > 0 else "`**"))
         if self.subcommands:
             output.append_line("").append_line('\n'.join(

--- a/src/commands/hello/__init__.py
+++ b/src/commands/hello/__init__.py
@@ -13,7 +13,7 @@ class Hello(Command):
     def __init__(self):
         super().__init__("hello", "Say \"hello\" to Memebot!")
 
-    def help_text(self) -> CommandOutput:
+    def long_description(self) -> CommandOutput:
         return CommandOutput().set_text("A simple ping command. Memebot should respond \"Hello!\"")
 
     async def exec(self, args: List[str], message: discord.Message) -> CommandOutput:

--- a/src/commands/hello/__init__.py
+++ b/src/commands/hello/__init__.py
@@ -11,10 +11,11 @@ class Hello(Command):
     """
 
     def __init__(self):
-        super().__init__("hello", "Say \"hello\" to Memebot!")
-
-    def long_description(self) -> CommandOutput:
-        return CommandOutput().set_text("A simple ping command. Memebot should respond \"Hello!\"")
+        super().__init__(
+            name="hello",
+            description="Say \"hello\" to Memebot!",
+            long_description="A simple ping command. Memebot should respond \"Hello!\""
+        )
 
     async def exec(self, args: List[str], message: discord.Message) -> CommandOutput:
         """

--- a/src/commands/help/__init__.py
+++ b/src/commands/help/__init__.py
@@ -12,19 +12,22 @@ class Help(Command):
     """
 
     def __init__(self):
-        super().__init__("help", "Learn how to use MemeBot", "[command_name]")
-
-    def long_description(self) -> CommandOutput:
-        return CommandOutput(
-            content="If no arguments are given, prints a short description of each command known by MemeBot.\n"
-                    "If given the name of a command, MemeBot will show more detailed information about that command.")
+        super().__init__(
+            name="help",
+            description="Learn how to use MemeBot",
+            long_description="If no arguments are given, prints a short description of each command known by MemeBot.\n"
+                             "If given the name of a command, "
+                             "MemeBot will show more detailed information about that command.",
+            example_args="[command_name]"
+        )
 
     async def exec(self, args: List[str], message: discord.Message) -> CommandOutput:
         """
-        Prints general help text for all messages
-        :param args: ignored
+        If no arguments are provided, prints general help text for all messages.
+        Optionally, a command path can be provided and this command will print that command's help text.
+        :param args: Optional command path
         :param message: Ignored
-        :return: A rundown of all of Memebot's commands.
+        :return: A CommandOutput object containing the information above.
         """
         if args:
             # Prepend a bang to the first arg if not already provided
@@ -35,7 +38,7 @@ class Help(Command):
                 # Attempt to find the command the user is asking for
                 command, _ = registry.parse_command_and_args(list(map(lambda arg: arg.lower(), cmd_path)))
             except ValueError:
-                return self.fail(f"Unrecognized command `!{''.join(cmd_path)}`")
+                return self.fail(f"Unrecognized command `!{' '.join(cmd_path)}`")
             return command.help_text()
         else:
             return CommandOutput().set_text("Commands:\n\t\t" + '\n\t\t'.join(

--- a/src/commands/help/__init__.py
+++ b/src/commands/help/__init__.py
@@ -2,7 +2,7 @@ from typing import List
 
 import discord
 
-from commands import Command, CommandOutput
+from commands import Command, CommandOutput, registry
 from commands.registry import top_level_command_registry
 
 
@@ -12,10 +12,12 @@ class Help(Command):
     """
 
     def __init__(self):
-        super().__init__("help", "Learn how to use MemeBot")
+        super().__init__("help", "Learn how to use MemeBot", "[command_name]")
 
-    def help_text(self) -> CommandOutput:
-        return CommandOutput().set_text("Runs this command.")
+    def long_description(self) -> CommandOutput:
+        return CommandOutput(
+            content="If no arguments are given, prints a short description of each command known by MemeBot.\n"
+                    "If given the name of a command, MemeBot will show more detailed information about that command.")
 
     async def exec(self, args: List[str], message: discord.Message) -> CommandOutput:
         """
@@ -24,6 +26,18 @@ class Help(Command):
         :param message: Ignored
         :return: A rundown of all of Memebot's commands.
         """
-        return CommandOutput().set_text("Commands:\n\t\t" + '\n\t\t'.join(
-            f"`!{cmd_name:5}` - {top_level_command_registry[cmd_name].command.description}" for cmd_name in
-            sorted(top_level_command_registry)))
+        if args:
+            # Prepend a bang to the first arg if not already provided
+            cmd_path = args.copy()
+            if not cmd_path[0].startswith('!'):
+                cmd_path[0] = '!' + cmd_path[0]
+            try:
+                # Attempt to find the command the user is asking for
+                command, _ = registry.parse_command_and_args(list(map(lambda arg: arg.lower(), cmd_path)))
+            except ValueError:
+                return self.fail(f"Unrecognized command `!{''.join(cmd_path)}`")
+            return command.help_text()
+        else:
+            return CommandOutput().set_text("Commands:\n\t\t" + '\n\t\t'.join(
+                f"`!{cmd_name:5}` - {top_level_command_registry[cmd_name].command.description}" for cmd_name in
+                sorted(top_level_command_registry)))

--- a/src/commands/poll/__init__.py
+++ b/src/commands/poll/__init__.py
@@ -20,7 +20,7 @@ class Poll(Command):
         self.reactions: List[str] = []
         self.lock = threading.Lock()
 
-    def help_text(self) -> CommandOutput:
+    def long_description(self) -> CommandOutput:
         return CommandOutput().set_text(
             "Create a simple poll with a question and multiple answers.\n"
             "If no answers are provided, :thumbsup: and :thumbsdown: will be used.")

--- a/src/commands/poll/__init__.py
+++ b/src/commands/poll/__init__.py
@@ -16,14 +16,15 @@ class Poll(Command):
     """
 
     def __init__(self):
-        super().__init__("poll", "Create a simple poll.", "\"question\" \"ans1\" \"ans2\" ... \"ansN\"")
+        super().__init__(
+            name="poll",
+            description="Create a simple poll.",
+            long_description="Create a simple poll with a question and multiple answers.\n"
+                             "If no answers are provided, :thumbsup: and :thumbsdown: will be used.",
+            example_args="\"question\" \"ans1\" \"ans2\" ... \"ansN\""
+        )
         self.reactions: List[str] = []
         self.lock = threading.Lock()
-
-    def long_description(self) -> CommandOutput:
-        return CommandOutput().set_text(
-            "Create a simple poll with a question and multiple answers.\n"
-            "If no answers are provided, :thumbsup: and :thumbsdown: will be used.")
 
     async def exec(self, args: List[str], message: discord.Message) -> 'CommandOutput':
         if len(args) < 1:

--- a/src/commands/role/__init__.py
+++ b/src/commands/role/__init__.py
@@ -33,15 +33,14 @@ class Role(Command):
     def __init__(self):
         super().__init__("role", "Self-contained role management")
 
-    def help_text(self) -> CommandOutput:
+    def long_description(self) -> CommandOutput:
         return CommandOutput().set_text(
             "Controls creating, joining, leaving, and listing permissionless mentionable roles. These roles are "
             "intended to serve as \"tags\" to allow mentioning multiple users at once."
         )
 
     async def exec(self, args: typing.List[str], message: discord.Message) -> CommandOutput:
-        return self.fail(
-            '\n'.join(f"`!{self.name} {sub.name} {sub.example_args}`: {sub.description}" for sub in Role.subcommands))
+        return self.help_text()
 
 
 def action_failure_message(action: str, target_name: str, msg: str = "") -> CommandOutput:

--- a/src/commands/role/__init__.py
+++ b/src/commands/role/__init__.py
@@ -31,12 +31,11 @@ class Role(Command):
     """
 
     def __init__(self):
-        super().__init__("role", "Self-contained role management")
-
-    def long_description(self) -> CommandOutput:
-        return CommandOutput().set_text(
-            "Controls creating, joining, leaving, and listing permissionless mentionable roles. These roles are "
-            "intended to serve as \"tags\" to allow mentioning multiple users at once."
+        super().__init__(
+            name="role",
+            description="Self-contained role management",
+            long_description="Controls creating, joining, leaving, and listing permissionless mentionable roles. "
+                             "These roles are intended to serve as \"tags\" to allow mentioning multiple users at once."
         )
 
     async def exec(self, args: typing.List[str], message: discord.Message) -> CommandOutput:

--- a/src/commands/role/create.py
+++ b/src/commands/role/create.py
@@ -11,10 +11,12 @@ class Create(Command):
     """
 
     def __init__(self):
-        super().__init__("create", "Creates <role>", "<role>")
-
-    def long_description(self) -> CommandOutput:
-        return CommandOutput().set_text("Create a new role to be managed by memebot.")
+        super().__init__(
+            name="create",
+            description="Creates <role>",
+            long_description="Create a new role to be managed by memebot.",
+            example_args="<role>"
+        )
 
     async def exec(self, args: List[str], message: discord.Message) -> CommandOutput:
         if len(args) != 1:

--- a/src/commands/role/create.py
+++ b/src/commands/role/create.py
@@ -13,7 +13,7 @@ class Create(Command):
     def __init__(self):
         super().__init__("create", "Creates <role>", "<role>")
 
-    def help_text(self) -> CommandOutput:
+    def long_description(self) -> CommandOutput:
         return CommandOutput().set_text("Create a new role to be managed by memebot.")
 
     async def exec(self, args: List[str], message: discord.Message) -> CommandOutput:

--- a/src/commands/role/delete.py
+++ b/src/commands/role/delete.py
@@ -13,7 +13,7 @@ class Delete(Command):
     def __init__(self):
         super().__init__("delete", "Deletes <role> if <role> has no members.", "<role>")
 
-    def help_text(self) -> CommandOutput:
+    def long_description(self) -> CommandOutput:
         return CommandOutput().set_text("Delete a Memebot-managed role if, and only if, the role has no members.")
 
     async def exec(self, args: List[str], message: discord.Message) -> CommandOutput:

--- a/src/commands/role/delete.py
+++ b/src/commands/role/delete.py
@@ -11,10 +11,12 @@ class Delete(Command):
     """
 
     def __init__(self):
-        super().__init__("delete", "Deletes <role> if <role> has no members.", "<role>")
-
-    def long_description(self) -> CommandOutput:
-        return CommandOutput().set_text("Delete a Memebot-managed role if, and only if, the role has no members.")
+        super().__init__(
+            name="delete",
+            description="Deletes <role> if <role> has no members.",
+            long_description="Delete a Memebot-managed role if, and only if, the role has no members.",
+            example_args="<role>"
+        )
 
     async def exec(self, args: List[str], message: discord.Message) -> CommandOutput:
         if len(args) != 1:

--- a/src/commands/role/join.py
+++ b/src/commands/role/join.py
@@ -11,10 +11,12 @@ class Join(Command):
     """
 
     def __init__(self):
-        super().__init__("join", "Adds caller to <role>", "<role>")
-
-    def long_description(self) -> CommandOutput:
-        return CommandOutput().set_text("Join an existing Memebot-managed role.")
+        super().__init__(
+            name="join",
+            description="Adds caller to <role>",
+            long_description="Join an existing Memebot-managed role.",
+            example_args="<role>"
+        )
 
     async def exec(self, args: List[str], message: discord.Message) -> CommandOutput:
         if len(args) != 1:

--- a/src/commands/role/join.py
+++ b/src/commands/role/join.py
@@ -13,7 +13,7 @@ class Join(Command):
     def __init__(self):
         super().__init__("join", "Adds caller to <role>", "<role>")
 
-    def help_text(self) -> CommandOutput:
+    def long_description(self) -> CommandOutput:
         return CommandOutput().set_text("Join an existing Memebot-managed role.")
 
     async def exec(self, args: List[str], message: discord.Message) -> CommandOutput:

--- a/src/commands/role/leave.py
+++ b/src/commands/role/leave.py
@@ -11,10 +11,12 @@ class Leave(Command):
     """
 
     def __init__(self):
-        super().__init__("leave", "Removes caller from <role>", "<role>")
-
-    def long_description(self) -> CommandOutput:
-        return CommandOutput().set_text("Leave a Memebot-managed role.")
+        super().__init__(
+            name="leave",
+            description="Removes caller from <role>",
+            long_description="Leave a Memebot-managed role.",
+            example_args="<role>"
+        )
 
     async def exec(self, args: List[str], message: discord.Message) -> CommandOutput:
         if len(args) != 1:

--- a/src/commands/role/leave.py
+++ b/src/commands/role/leave.py
@@ -13,7 +13,7 @@ class Leave(Command):
     def __init__(self):
         super().__init__("leave", "Removes caller from <role>", "<role>")
 
-    def help_text(self) -> CommandOutput:
+    def long_description(self) -> CommandOutput:
         return CommandOutput().set_text("Leave a Memebot-managed role.")
 
     async def exec(self, args: List[str], message: discord.Message) -> CommandOutput:

--- a/src/commands/role/list.py
+++ b/src/commands/role/list.py
@@ -14,7 +14,7 @@ class List(Command):
     def __init__(self):
         super().__init__("list", "List all roles managed by Memebot, or list all members of a role.", "[role]")
 
-    def help_text(self) -> CommandOutput:
+    def long_description(self) -> CommandOutput:
         return CommandOutput().set_text("List all roles managed by Memebot, or provide the name of a role and list "
                                         "all members of that role.")
 

--- a/src/commands/role/list.py
+++ b/src/commands/role/list.py
@@ -12,11 +12,13 @@ class List(Command):
     """
 
     def __init__(self):
-        super().__init__("list", "List all roles managed by Memebot, or list all members of a role.", "[role]")
-
-    def long_description(self) -> CommandOutput:
-        return CommandOutput().set_text("List all roles managed by Memebot, or provide the name of a role and list "
-                                        "all members of that role.")
+        super().__init__(
+            name="list",
+            description="List all roles managed by Memebot, or list all members of a role.",
+            long_description="List all roles managed by Memebot, or provide the name of a role and list "
+                             "all members of that role.",
+            example_args="[role]"
+        )
 
     async def exec(self, args: typing.List[str], message: discord.Message) -> CommandOutput:
         if len(args) > 1:


### PR DESCRIPTION
The `!help` command will now print longer descriptions and usage instructions for other commands when given their name as an argument. For example:

> !help hello

> A simple ping command. Memebot should respond "Hello!"
>
> **`!hello`**

> !help role list

> List all roles managed by Memebot, or provide the name of a role and list all members of that role.
>
> **`!role list [role]`**

The refactors to the [`Help`](src/commands/help/__init__.py) class were pretty minor, and only include checking for arguments, finding a command that matches the arguments, and printing that command's help text. The behavior for usage with no arguments remains the same.

Several refactors were made to the [`Command`](src/commands/command.py) class to allow it to have more nuanced behavior with regard to helping the user:

1. The abstract method `help_text` has been made non-abstract, and now outputs the message that used to be crafted by `fail`
2. A new abstract method called `long_description` takes the place of `help_text`'s previous purpose.
3. `fail` by default now makes a call to `help_text` and then appends any extra information and sets the `CommandOutput`'s status to `FAIL`

This was done so that we could output the same information previously derived by `fail` without having to regard the command as a failure.
