### PR TITLE
Add workflow for triggering automatic deployment

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -2,8 +2,6 @@
 name: Trigger deployment
 
 on:
-  pull_request:
-    branches: ["master"]
   workflow_run:
     workflows: ["Docker"]
     branches: ["master"]

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -2,6 +2,8 @@
 name: Trigger deployment
 
 on:
+  pull_request:
+    branches: ["master"]
   workflow_run:
     workflows: ["Docker"]
     branches: ["master"]

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,20 @@
+---
+name: Trigger deployment
+
+on:
+  pull_request:
+    branches: ["master"]
+  workflow_run:
+    workflows: ["Docker"]
+    branches: ["master"]
+    types: ["completed"]
+
+jobs:
+  prod:
+    runs-on: ubuntu-latest
+    environment: Production
+    permissions:
+      deployments: write
+    steps:
+      - name: Deploy
+        run: echo "Triggering deployment..."

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -9,6 +9,8 @@ on:
   pull_request:
     paths:
       - docker/*
+  schedule:
+    - cron: '0 12 * * 6'
 
 env:
   # Use docker.io for Docker Hub if empty


### PR DESCRIPTION
 This workflow runs a simple command under the "Production" environment, which causes GitHub to trigger a deployment event, which is sent to an app I've been developing which can automatically deploy Memebot.

The app takes care of the actual deployment logic, so this workflow is only meant to create the event to trigger the app. Using the app allows me to keep SSH keys on the server, and not have to upload to GitHub or trust that an SSH action that somebody has uploaded will never have malicious code.

This initial commit has a trigger for pull requests just to make sure it works. Before it merges, that trigger will be removed so that it only runs after a successful Docker image build.

There is also an update to the Docker workflow to rebuild every Saturday morning so that it will inherit any package updates from Ubuntu.
