### PR TITLE
Add ability to list roles by user

### DIFF
--- a/src/commands/role.py
+++ b/src/commands/role.py
@@ -86,6 +86,7 @@ async def role(ctx: discord.ext.commands.Context) -> None:
     !role delete <role>: Deletes <role> if <role> has no members
     !role list: List all bot-managed roles
     !role list <role>: Lists members of <role>
+    !role list <user>: Lists roles of a user
 
     Note that because role names are not unique, these commands will act
     on the first instance (hierarchically) of a role with name <role>

--- a/src/commands/role.py
+++ b/src/commands/role.py
@@ -226,9 +226,9 @@ async def leave(
 
 @role.command(
     name="list",
-    brief="List all roles managed by Memebot, or list all members of a role.",
-    help="List all roles managed by Memebot, or provide the name of a role and list "
-    "all members of that role.",
+    brief="List all roles managed by Memebot, all members of a given role, or all roles of a given user.",
+    help="List all roles managed by Memebot. Optionally, if the name of a role is provided, list "
+    "all members of that role, or if a username is provided, list all roles for that user.",
 )
 async def role_list(
     ctx: discord.ext.commands.Context,

--- a/src/commands/role.py
+++ b/src/commands/role.py
@@ -175,11 +175,11 @@ async def join(
     if not isinstance(author, discord.Member):
         # Ensure the command was called from within a server text channel
         raise RoleLocationError
-    if discord.utils.get(author.roles, name=target_role.name):
+    if discord.utils.get(author.roles, name=tgt_role.name):
         raise RoleActionError(
             ctx.command.name,
-            target_role.name,
-            f"{author.name} already a member of `@{target_role.name}`",
+            tgt_role.name,
+            f"{author.name} already a member of `@{tgt_role.name}`",
         )
     try:
         await author.add_roles(tgt_role, reason=get_reason(author.name))
@@ -233,13 +233,13 @@ async def leave(
 )
 async def role_list(
     ctx: discord.ext.commands.Context,
-    role: Optional[Union[LowercaseRoleConverter, discord.Member]],
+    role_or_user: Optional[Union[LowercaseRoleConverter, discord.Member]],
 ) -> None:
     """
     List all roles managed by Memebot, or all members of a role managed by Memebot.
     """
     # TODO: Replace this cast with typing.Annotation after migrating to discord.py 2.0
-    target = cast(Optional[Union[discord.Role, discord.Member]], role)
+    target = cast(Optional[Union[discord.Role, discord.Member]], role_or_user)
 
     if not ctx.guild:
         raise RoleLocationError


### PR DESCRIPTION
By running `!role list <username>`, you can now list the MemeBot-managed roles for a given user. The argument to `!role list` can now be either a role or a user, so if there is a user and a role with the same name, the role will take priority when parsing and converting the arguments. 