### PR TITLE
Use Dependabot to update GitHub Actions

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,15 @@
+---
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: saturday
+      time: "08:00"
+      timezone: "America/Chicago"


### PR DESCRIPTION
Workflows can fall out of date, and shouldn't affect code correctness on updates, so Dependabot will manage updates. Pip packages are not watched because there are no tests yet, and those upgrades could easily break code. As such, this patch only solves a piece of #93.
