### PR TITLE
Use latest version of cosign available for Docker workflow

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -41,8 +41,6 @@ jobs:
       - name: Install cosign
         if: github.event_name != 'pull_request'
         uses: sigstore/cosign-installer@7e0881f8fe90b25e305bbf0309761e9314607e25
-        with:
-          cosign-release: 'v1.9.0'
 
 
       # Workaround: https://github.com/docker/build-push-action/issues/461


### PR DESCRIPTION
Using a pinned version of cosign has caused the Docker workflow to fall out of date and fail to sign the image. Rather than have this periodically happen, we will use the latest version available by simply not specifying a version.
