### PR TITLE
Upgrade to discord.py 2.1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-discord.py==1.7.3
-discord.py-stubs==1.7.3
+discord.py==2.1.0
 pymongo
 tweepy
 aiohttp

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 discord.py==2.1.0
 pymongo
+pymongo-stubs
 tweepy
 aiohttp

--- a/src/commands/help.py
+++ b/src/commands/help.py
@@ -56,7 +56,7 @@ class Help(discord.ext.commands.DefaultHelpCommand):
         self.cache_next = False
 
     def get_ending_note(self) -> str:
-        return f"Type {self.clean_prefix}{self.invoked_with} <command> for more info on a command."
+        return f"Type {self.context.clean_prefix}{self.invoked_with} <command> for more info on a command."
 
     async def subcommand_not_found(
         self, command: discord.ext.commands.Command, string: str

--- a/src/commands/poll.py
+++ b/src/commands/poll.py
@@ -17,6 +17,8 @@ async def poll(ctx: discord.ext.commands.Context, question: str, *choices: str) 
     """
     Poll command for creating a simple, reaction-based poll.
     """
+    if not ctx.command:
+        raise exception.MemebotInternalError("Cannot get command from context")
     embed = discord.Embed(
         title=":bar_chart: **New Poll!**",
         description=f"_{question}_",
@@ -34,7 +36,7 @@ async def poll(ctx: discord.ext.commands.Context, question: str, *choices: str) 
         ["yea", "nay"],
         ["nay", "yea"],
     ):
-        embed.add_field(name=":thumbsup:", value=":)").add_field(
+        embed.add_field(name=":thumbsup:", value=":)").add_field(  # type: ignore[attr-defined]
             name=":thumbsdown:", value=":("
         )
         reactions = [":thumbsup:", ":thumbsdown:"]

--- a/src/commands/role.py
+++ b/src/commands/role.py
@@ -95,7 +95,7 @@ async def role(ctx: discord.ext.commands.Context) -> None:
         raise exception.MemebotUserError
 
 
-@role.command(
+@role.command(  # type: ignore
     brief="Creates <role>", help="Create a new role to be managed by Memebot."
 )
 async def create(ctx: discord.ext.commands.Context, role_name: str) -> None:
@@ -105,6 +105,8 @@ async def create(ctx: discord.ext.commands.Context, role_name: str) -> None:
     guild = ctx.guild
     author = ctx.author
     target_name = role_name.lower()
+    if not ctx.command:
+        raise exception.MemebotInternalError("Cannot get command from context")
     if "@" in target_name:
         raise RoleActionError(
             ctx.command.name,
@@ -125,13 +127,13 @@ async def create(ctx: discord.ext.commands.Context, role_name: str) -> None:
         )
     except discord.Forbidden:
         raise RolePermissionError(ctx.command.name, target_name)
-    except (discord.HTTPException, discord.InvalidArgument):
+    except (discord.HTTPException, TypeError):
         raise RoleActionError(ctx.command.name, target_name)
 
     await ctx.send(f"Created new role {new_role.mention}!")
 
 
-@role.command(
+@role.command(  # type: ignore
     brief="Deletes <role> if <role> has no members.",
     help="Delete a Memebot-managed role if, and only if, the role has no members.",
 )
@@ -140,6 +142,8 @@ async def delete(
 ) -> None:
     # TODO: Replace this cast with typing.Annotation after migrating to discord.py 2.0
     tgt_role = cast(discord.Role, target_role)
+    if not ctx.command:
+        raise exception.MemebotInternalError("Cannot get command from context")
 
     # Ensure the role is empty before deleting
     if len(tgt_role.members) > 0:
@@ -159,7 +163,7 @@ async def delete(
     await ctx.send(f"Deleted role `@{tgt_role.name}`")
 
 
-@role.command(
+@role.command(  # type: ignore
     brief="Adds caller to <role>", help="Join an existing Memebot-managed role."
 )
 async def join(
@@ -170,6 +174,8 @@ async def join(
     """
     # TODO: Replace this cast with typing.Annotation after migrating to discord.py 2.0
     tgt_role = cast(discord.Role, target_role)
+    if not ctx.command:
+        raise exception.MemebotInternalError("Cannot get command from context")
 
     author = ctx.author
     if not isinstance(author, discord.Member):
@@ -191,7 +197,7 @@ async def join(
     await ctx.send(f"{author.name} successfully joined `@{tgt_role.name}`")
 
 
-@role.command(
+@role.command(  # type: ignore
     brief="Removes caller from <role>",
     help="Leave a Memebot-managed role.",
 )
@@ -203,6 +209,8 @@ async def leave(
     """
     # TODO: Replace this cast with typing.Annotation after migrating to discord.py 2.0
     tgt_role = cast(discord.Role, target_role)
+    if not ctx.command:
+        raise exception.MemebotInternalError("Cannot get command from context")
 
     author = ctx.author
     if author not in tgt_role.members:
@@ -225,7 +233,7 @@ async def leave(
     await ctx.send(f"{author.name} successfully left `@{tgt_role.name}`")
 
 
-@role.command(
+@role.command(  # type: ignore
     name="list",
     brief="List all roles managed by Memebot, all members of a given role, or all roles of a given user.",
     help="List all roles managed by Memebot. Optionally, if the name of a role is provided, list "
@@ -240,6 +248,8 @@ async def role_list(
     """
     # TODO: Replace this cast with typing.Annotation after migrating to discord.py 2.0
     target = cast(Optional[Union[discord.Role, discord.Member]], role_or_user)
+    if not ctx.command:
+        raise exception.MemebotInternalError("Cannot get command from context")
 
     if not ctx.guild:
         raise RoleLocationError

--- a/src/memebot.py
+++ b/src/memebot.py
@@ -1,4 +1,5 @@
-import discord.ext.commands.bot
+import discord
+import discord.ext.commands
 
 import commands
 import config
@@ -12,6 +13,8 @@ async def on_ready() -> None:
     """
     Determines what the bot does as soon as it is logged into discord
     """
+    if not memebot.user:
+        raise exception.MemebotInternalError("Cannot get logged in user")
     log.info(f"Logged in as {memebot.user}")
     if config.twitter_enabled:
         twitter.init(memebot.user)

--- a/src/memebot.py
+++ b/src/memebot.py
@@ -14,7 +14,7 @@ async def on_ready() -> None:
     Determines what the bot does as soon as it is logged into discord
     """
     if not memebot.user:
-        raise exception.MemebotInternalError("Cannot get logged in user")
+        raise exception.MemebotInternalError("Memebot is not logged in to Discord")
     log.info(f"Logged in as {memebot.user}")
     if config.twitter_enabled:
         twitter.init(memebot.user)


### PR DESCRIPTION
After upgrading the requirements and testing, i found that everything worked. The only thing that needed to be changed was our usage of the [`clean_prefix` property](https://discordpy.readthedocs.io/en/stable/migrating.html#id2) in the code for the help command. 

Version 2.0+ is fully typed, so the stubs are no longer needed and can be removed from the requirements. 