### PR TITLE
Properly annotate role subcommand arguments

### DIFF
--- a/src/commands/role.py
+++ b/src/commands/role.py
@@ -1,4 +1,4 @@
-from typing import Optional, Any, cast, Union
+from typing import Optional, Any, Union, Annotated
 
 import discord
 import discord.ext.commands
@@ -138,42 +138,40 @@ async def create(ctx: discord.ext.commands.Context, role_name: str) -> None:
     help="Delete a Memebot-managed role if, and only if, the role has no members.",
 )
 async def delete(
-    ctx: discord.ext.commands.Context, target_role: LowercaseRoleConverter
+    ctx: discord.ext.commands.Context,
+    target_role: Annotated[discord.Role, LowercaseRoleConverter],
 ) -> None:
-    # TODO: Replace this cast with typing.Annotation after migrating to discord.py 2.0
-    tgt_role = cast(discord.Role, target_role)
     if not ctx.command:
         raise exception.MemebotInternalError("Cannot get command from context")
 
     # Ensure the role is empty before deleting
-    if len(tgt_role.members) > 0:
+    if len(target_role.members) > 0:
         raise RoleActionError(
             ctx.command.name,
-            tgt_role.name,
+            target_role.name,
             "Roles must have no members to be deleted.",
         )
 
     try:
-        await tgt_role.delete(reason=get_reason(ctx.author.name))
+        await target_role.delete(reason=get_reason(ctx.author.name))
     except discord.Forbidden:
-        raise RolePermissionError(ctx.command.name, tgt_role.name)
+        raise RolePermissionError(ctx.command.name, target_role.name)
     except discord.HTTPException:
-        raise RoleActionError(ctx.command.name, tgt_role.name)
+        raise RoleActionError(ctx.command.name, target_role.name)
 
-    await ctx.send(f"Deleted role `@{tgt_role.name}`")
+    await ctx.send(f"Deleted role `@{target_role.name}`")
 
 
 @role.command(  # type: ignore
     brief="Adds caller to <role>", help="Join an existing Memebot-managed role."
 )
 async def join(
-    ctx: discord.ext.commands.Context, target_role: LowercaseRoleConverter
+    ctx: discord.ext.commands.Context,
+    target_role: Annotated[discord.Role, LowercaseRoleConverter],
 ) -> None:
     """
     Join an existing Memebot-managed role
     """
-    # TODO: Replace this cast with typing.Annotation after migrating to discord.py 2.0
-    tgt_role = cast(discord.Role, target_role)
     if not ctx.command:
         raise exception.MemebotInternalError("Cannot get command from context")
 
@@ -181,20 +179,20 @@ async def join(
     if not isinstance(author, discord.Member):
         # Ensure the command was called from within a server text channel
         raise RoleLocationError
-    if discord.utils.get(author.roles, name=tgt_role.name):
+    if discord.utils.get(author.roles, name=target_role.name):
         raise RoleActionError(
             ctx.command.name,
-            tgt_role.name,
-            f"{author.name} already a member of `@{tgt_role.name}`",
+            target_role.name,
+            f"{author.name} already a member of `@{target_role.name}`",
         )
     try:
-        await author.add_roles(tgt_role, reason=get_reason(author.name))
+        await author.add_roles(target_role, reason=get_reason(author.name))
     except discord.Forbidden:
-        raise RolePermissionError(ctx.command.name, tgt_role.name)
+        raise RolePermissionError(ctx.command.name, target_role.name)
     except discord.HTTPException:
-        raise RoleActionError(ctx.command.name, tgt_role.name)
+        raise RoleActionError(ctx.command.name, target_role.name)
 
-    await ctx.send(f"{author.name} successfully joined `@{tgt_role.name}`")
+    await ctx.send(f"{author.name} successfully joined `@{target_role.name}`")
 
 
 @role.command(  # type: ignore
@@ -202,35 +200,34 @@ async def join(
     help="Leave a Memebot-managed role.",
 )
 async def leave(
-    ctx: discord.ext.commands.Context, target_role: LowercaseRoleConverter
+    ctx: discord.ext.commands.Context,
+    target_role: Annotated[discord.Role, LowercaseRoleConverter],
 ) -> None:
     """
     Leave a Memebot-managed role of which the caller is a member
     """
-    # TODO: Replace this cast with typing.Annotation after migrating to discord.py 2.0
-    tgt_role = cast(discord.Role, target_role)
     if not ctx.command:
         raise exception.MemebotInternalError("Cannot get command from context")
 
     author = ctx.author
-    if author not in tgt_role.members:
+    if author not in target_role.members:
         raise RoleActionError(
             ctx.command.name,
-            tgt_role.name,
-            f"User is not a member of `@{tgt_role.name}`.",
+            target_role.name,
+            f"User is not a member of `@{target_role.name}`.",
         )
     if not isinstance(author, discord.Member):
         # Ensure the command was called from within a server text channel
         raise RoleLocationError
 
     try:
-        await author.remove_roles(tgt_role, reason=get_reason(author.name))
+        await author.remove_roles(target_role, reason=get_reason(author.name))
     except discord.Forbidden:
-        raise RolePermissionError(ctx.command.name, tgt_role.name)
+        raise RolePermissionError(ctx.command.name, target_role.name)
     except discord.HTTPException:
-        raise RoleActionError(ctx.command.name, tgt_role.name)
+        raise RoleActionError(ctx.command.name, target_role.name)
 
-    await ctx.send(f"{author.name} successfully left `@{tgt_role.name}`")
+    await ctx.send(f"{author.name} successfully left `@{target_role.name}`")
 
 
 @role.command(  # type: ignore
@@ -241,13 +238,13 @@ async def leave(
 )
 async def role_list(
     ctx: discord.ext.commands.Context,
-    role_or_user: Optional[Union[LowercaseRoleConverter, discord.Member]],
+    target: Optional[
+        Union[Annotated[discord.Role, LowercaseRoleConverter], discord.Member]
+    ],
 ) -> None:
     """
     List all roles managed by Memebot, or all members of a role managed by Memebot.
     """
-    # TODO: Replace this cast with typing.Annotation after migrating to discord.py 2.0
-    target = cast(Optional[Union[discord.Role, discord.Member]], role_or_user)
     if not ctx.command:
         raise exception.MemebotInternalError("Cannot get command from context")
 

--- a/src/commands/role.py
+++ b/src/commands/role.py
@@ -60,6 +60,9 @@ class LowercaseRoleConverter(discord.ext.commands.RoleConverter):
         return await super().convert(ctx, arg.lower())
 
 
+RoleIgnoreCase = Annotated[discord.Role, LowercaseRoleConverter]
+
+
 def get_reason(author_name: str) -> str:
     """
     Create a default reason string that will be embedded in new roles.
@@ -139,7 +142,7 @@ async def create(ctx: discord.ext.commands.Context, role_name: str) -> None:
 )
 async def delete(
     ctx: discord.ext.commands.Context,
-    target_role: Annotated[discord.Role, LowercaseRoleConverter],
+    target_role: RoleIgnoreCase,
 ) -> None:
     if not ctx.command:
         raise exception.MemebotInternalError("Cannot get command from context")
@@ -167,7 +170,7 @@ async def delete(
 )
 async def join(
     ctx: discord.ext.commands.Context,
-    target_role: Annotated[discord.Role, LowercaseRoleConverter],
+    target_role: RoleIgnoreCase,
 ) -> None:
     """
     Join an existing Memebot-managed role
@@ -201,7 +204,7 @@ async def join(
 )
 async def leave(
     ctx: discord.ext.commands.Context,
-    target_role: Annotated[discord.Role, LowercaseRoleConverter],
+    target_role: RoleIgnoreCase,
 ) -> None:
     """
     Leave a Memebot-managed role of which the caller is a member
@@ -238,9 +241,7 @@ async def leave(
 )
 async def role_list(
     ctx: discord.ext.commands.Context,
-    target: Optional[
-        Union[Annotated[discord.Role, LowercaseRoleConverter], discord.Member]
-    ],
+    target: Optional[Union[RoleIgnoreCase, discord.Member]],
 ) -> None:
     """
     List all roles managed by Memebot, or all members of a role managed by Memebot.


### PR DESCRIPTION
Before this, it was not possible to annotate command arguments with with their type while also using an argument converter. Now in 2.0+, discord.py supports using `typing.Annotated` to annotate an arguments type and provide a custom converter.

https://discordpy.readthedocs.io/en/stable/ext/commands/commands.html#typing-annotated

Part of #119 