### PR TITLE
Add interactions to poll command

### DIFF
--- a/src/commands/poll.py
+++ b/src/commands/poll.py
@@ -74,15 +74,16 @@ class PollResult:
 
     def to_embed(self) -> discord.Embed:
         embed = discord.Embed(
-            title=f":bar_chart: **{self.question}**",
-            # description=f"_{self.question}_",
+            title=f":bar_chart: **New Poll!**",
+            description=f"_{self.question}_",
             color=constants.COLOR,
             timestamp=datetime.utcnow(),
         )
         for i, (choice, voters) in enumerate(self.votes.items()):
             voter_names = map(lambda x: x.display_name, voters)
             embed.add_field(
-                name=f'{chr(ord("🇦") + i)} {choice}', value="\n".join(voter_names)
+                name=f'{chr(ord("🇦") + i)} {choice} ({len(voters)})',
+                value="\n".join(voter_names),
             )
 
         return embed


### PR DESCRIPTION
Instead of using reactions for the poll command, we can instead use interaction buttons. This also allows us to dynamically update the poll embed with the names of who voted. 