### PR TITLE
Add interactions to poll command

### DIFF
--- a/src/commands/poll.py
+++ b/src/commands/poll.py
@@ -74,15 +74,16 @@ class PollResult:
 
     def to_embed(self) -> discord.Embed:
         embed = discord.Embed(
-            title=f":bar_chart: **{self.question}**",
-            # description=f"_{self.question}_",
+            title=f":bar_chart: **New Poll!**",
+            description=f"_{self.question}_",
             color=constants.COLOR,
             timestamp=datetime.utcnow(),
         )
         for i, (choice, voters) in enumerate(self.votes.items()):
             voter_names = map(lambda x: x.display_name, voters)
             embed.add_field(
-                name=f'{chr(ord("🇦") + i)} {choice}', value="\n".join(voter_names)
+                name=f'{chr(ord("🇦") + i)} {choice} ({len(voters)})',
+                value="\n".join(voter_names),
             )
 
         return embed

--- a/src/commands/poll.py
+++ b/src/commands/poll.py
@@ -1,6 +1,6 @@
 from collections import OrderedDict
 from datetime import datetime
-from typing import Optional, Union
+from typing import Optional, Union, Any
 
 import discord
 import discord.ext.commands
@@ -115,7 +115,7 @@ class VoteButton(discord.ui.Button):
     results: PollResult
     value: str
 
-    def __init__(self, results: PollResult, value: str, **kwargs):
+    def __init__(self, results: PollResult, value: str, **kwargs: Any):
         super().__init__(**kwargs)
         self.results = results
         self.value = value


### PR DESCRIPTION
Follow up from #154, which was closed accidentally in a git mishap. 

Instead of using reactions for the poll command, we can instead use interaction buttons. This also allows us to dynamically update the poll embed with the names of who voted.

The poll mimics the previous behavior with special thumbs up/down emojis as choices for yes or no questions.