### PR TITLE
Clean apt lists after install dependencies in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,9 @@ COPY requirements.txt requirements.txt
 RUN \
     apt-get update -y && \
     # gcc is required to build package aiohttp (https://docs.aiohttp.org/en/stable/) required by discord.py
-    apt-get install --no-install-recommends -y gcc=4:10.2.1-1
+    apt-get install --no-install-recommends -y gcc=4:10.2.1-1 && \
+    # Remove apt lists
+    rm -rf /var/lib/apt/lists/*
 
 # Set up venv.
 RUN python3 -m venv /opt/venv


### PR DESCRIPTION
This had previously been done in our Dockerfile but was reintroduced by b81f11823c34bc59460918544cf5072304f7a785
