### PR TITLE
Add paywall command

### DIFF
--- a/memebot/client.py
+++ b/memebot/client.py
@@ -95,6 +95,8 @@ def get_memebot() -> discord.ext.commands.Bot:
 
     new_memebot.tree.add_command(commands.hello)
     new_memebot.tree.add_command(commands.role)
+    new_memebot.tree.add_command(commands.paywall)
+    new_memebot.tree.add_command(commands.paywall_context_menu)
 
     new_memebot.add_listener(on_ready)
     new_memebot.add_listener(on_interaction)

--- a/memebot/commands/__init__.py
+++ b/memebot/commands/__init__.py
@@ -1,2 +1,4 @@
 from .hello import hello
 from .role import role
+from .paywall import paywall, paywall_context_menu
+

--- a/memebot/commands/paywall.py
+++ b/memebot/commands/paywall.py
@@ -1,0 +1,43 @@
+from typing import Optional
+import re
+
+import discord
+
+from memebot import log
+from memebot.lib import exception
+
+
+@discord.app_commands.command()
+async def paywall(interaction: discord.Interaction, link: str) -> None:
+    """
+    Generate the given link without a paywall. If replying to a message, use
+    the link in the replied-to message
+    """
+    await interaction.response.send_message(
+        f"Link without paywall: https://archive.is/newest/{link}"
+    )
+
+
+@discord.app_commands.context_menu(name="paywall")
+async def paywall_context_menu(
+    interaction: discord.Interaction, message: discord.Message
+) -> None:
+    link = extract_link(message)
+    await interaction.response.send_message(
+        f"Link without paywall: https://archive.is/newest/{link}"
+    )
+
+
+def extract_link(message: discord.Message) -> str:
+    """Extracts a link from the given message's embeds or content"""
+    # Try embeds first because it's easier and more reliable.
+    for embed in message.embeds:
+        if embed.url:
+            return embed.url
+
+    # This should return a list of strings:
+    # https://docs.python.org/3/library/re.html#re.findall
+    for match in re.findall(r"https?://\S+", message.content):
+        return match
+
+    raise exception.MemebotUserError("Cannot extract link from replied-to message")

--- a/tests/commands/test_paywall.py
+++ b/tests/commands/test_paywall.py
@@ -1,0 +1,45 @@
+from unittest import mock
+
+import discord.ext.commands
+import pytest
+
+from memebot import commands
+from memebot.lib import exception
+
+class StringContaining(str):
+    def __eq__(self, other):
+            return self in other
+
+
+@pytest.mark.asyncio
+async def test_paywall_command(mock_interaction: mock.Mock) -> None:
+    link = "https://foo.com/poop"
+
+    await commands.paywall.callback(mock_interaction, link)
+    mock_interaction.response.send_message.assert_awaited_once_with(StringContaining(link))
+
+@pytest.mark.asyncio
+async def test_paywall_context_menu_succeeds_with_embed(mock_interaction: mock.Mock, mock_message:mock.Mock) -> None:
+    link = "https://foo.com/poop"
+    bad_link = "http://bar.com/fart"
+    mock_message.embeds = [mock.Mock(url=u) for u in (link, bad_link)]
+
+    await commands.paywall_context_menu.callback(mock_interaction, mock_message)
+    mock_interaction.response.send_message.assert_awaited_once_with(StringContaining(link))
+
+@pytest.mark.asyncio
+async def test_paywall_context_menu_succeeds_with_content(mock_interaction: mock.Mock, mock_message:mock.Mock) -> None:
+    link = "https://foo.com/poop"
+    bad_link = "http://bar.com/fart"
+    mock_message.content = f"Hey gamers, check this out {link} {bad_link}"
+
+    await commands.paywall_context_menu.callback(mock_interaction, mock_message)
+    mock_interaction.response.send_message.assert_awaited_once_with(StringContaining(link))
+
+@pytest.mark.asyncio
+async def test_paywall_context_menu_fails_with_no_link(mock_interaction: mock.Mock, mock_message:mock.Mock) -> None:
+    mock_message.content = ""
+    with pytest.raises(exception.MemebotUserError):
+        await commands.paywall_context_menu.callback(mock_interaction, mock_message)
+    mock_interaction.response.send_message.assert_not_awaited()
+


### PR DESCRIPTION
This lets you quickly get an archive.is paywall-free link. You can invoke by using the `/paywall` command with the link provided or by accessing the paywall command in the context menu of a message with a link. 