### PR TITLE
Add black dependency to test build

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
+black~=25.1.0
 mypy~=1.16.0
 pytest~=8.4.0
 pytest-asyncio~=1.0.0


### PR DESCRIPTION
Includes a dependency on `black` for test builds. Added convenience for those who prefer to use a bundled package rather than a system package
