### PR TITLE
Simplify global logger

### DIFF
--- a/memebot/log/__init__.py
+++ b/memebot/log/__init__.py
@@ -9,34 +9,40 @@ from memebot import config
 from . import formatter, logger
 
 memebot_logger: logger.MemeBotLogger
-stdout_logger: logging.Logger
 
 
 def log(level: int, msg: str, *args: Any, **kwargs: Any) -> None:
+    kwargs["stacklevel"] = kwargs.get("stacklevel", 1) + 1
     memebot_logger.log(level, msg, *args, **kwargs)
 
 
 def debug(msg: str, *args: Any, **kwargs: Any) -> None:
+    kwargs["stacklevel"] = kwargs.get("stacklevel", 1) + 1
     memebot_logger.debug(msg, *args, **kwargs)
 
 
 def info(msg: str, *args: Any, **kwargs: Any) -> None:
+    kwargs["stacklevel"] = kwargs.get("stacklevel", 1) + 1
     memebot_logger.info(msg, *args, **kwargs)
 
 
 def warning(msg: str, *args: Any, **kwargs: Any) -> None:
+    kwargs["stacklevel"] = kwargs.get("stacklevel", 1) + 1
     memebot_logger.warning(msg, *args, **kwargs)
 
 
 def error(msg: str, *args: Any, **kwargs: Any) -> None:
+    kwargs["stacklevel"] = kwargs.get("stacklevel", 1) + 1
     memebot_logger.error(msg, *args, **kwargs)
 
 
 def critical(msg: str, *args: Any, **kwargs: Any) -> None:
+    kwargs["stacklevel"] = kwargs.get("stacklevel", 1) + 1
     memebot_logger.critical(msg, *args, **kwargs)
 
 
 def exception(msg: str, exc_info: Any = True, *args: Any, **kwargs: Any) -> None:
+    kwargs["stacklevel"] = kwargs.get("stacklevel", 1) + 1
     memebot_logger.exception(msg, *args, exc_info=exc_info, **kwargs)
 
 
@@ -50,7 +56,6 @@ def configure_logging() -> None:
 
     # Redirect all stdout to a logger, as some packages in the stdlib still use print
     # for debug messages
-    global stdout_logger
     stdout_logger = logging.getLogger("stdout")
     contextlib.redirect_stdout(stdout_logger).__enter__()  # type: ignore[type-var]
 
@@ -69,5 +74,6 @@ def interaction(
     Logging wrapper to prefix a log message with the interaction ID. This is helpful
     for tracking the information flow for an interaction.
     """
+    kwargs["stacklevel"] = kwargs.get("stacklevel", 1) + 1
     # Highlight the interaction id
     log(level, f"\033[1mInteraction {inter.id}\033[22m {msg}", *args, **kwargs)

--- a/memebot/log/filter.py
+++ b/memebot/log/filter.py
@@ -1,0 +1,14 @@
+import logging
+import os.path
+
+
+class MemebotLogFilter(logging.Filter):
+    """
+    Replaces module name with fully qualified module path
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool | logging.LogRecord:
+        file_path_no_ext = os.path.splitext(os.path.relpath(record.pathname))[0]
+        module_path = file_path_no_ext.replace(os.sep, ".")
+        record.module = module_path
+        return record

--- a/memebot/log/formatter.py
+++ b/memebot/log/formatter.py
@@ -1,4 +1,3 @@
-import contextlib
 import logging
 
 
@@ -10,8 +9,8 @@ class MemeBotLogFormatter(logging.Formatter):
     def __init__(self) -> None:
         super().__init__(
             # This format will print as such:
-            # [YYYY-MM-DD HH:MM:SS.uuu   LOGLEVEL    log.statement.call.site:line] I am a log message!
-            fmt="[{asctime}\t{levelname}\t{_callsite}:{_lineno}]\t{message}",
+            # [YYYY-MM-DD HH:MM:SS.uuu LOGLEVEL log.statement.call.site:line] I am a log message!
+            fmt="[{asctime} {levelname} {module}:{lineno}]\t{message}",
             style="{",
         )
         # Have the milliseconds in timestamps separated by '.' instead of ','
@@ -23,12 +22,11 @@ class MemeBotLogFormatter(logging.Formatter):
         This override causes multi-line messages to have formatting on every line
         """
         buf = []
-        full_message = record.message
-        with contextlib.ExitStack() as stack:
-            stack.callback(lambda: setattr(record, "message", full_message))
-            for line in full_message.split("\n"):
-                record.message = line
-                buf.append(self._style.format(record))
+        original_message = record.message
+        for line in original_message.split("\n"):
+            record.message = line
+            buf.append(self._style.format(record))
+        record.message = original_message
         return "\n".join(buf)
 
     def format(self, record: logging.LogRecord) -> str:
@@ -44,19 +42,20 @@ class MemeBotLogFormatter(logging.Formatter):
         if not record.exc_info:
             return super(MemeBotLogFormatter, self).format(record)
 
-        with contextlib.ExitStack() as stack:
-            # Pop out the record's exception info so that it doesn't get appended
-            # to the message
-            exc_info = record.exc_info
-            record.exc_info = None
-            stack.callback(lambda: setattr(record, "exc_info", exc_info))
-            # Format the message without the exception
-            base_output = super(MemeBotLogFormatter, self).format(record)
-            full_message = record.message
-            # Store the traceback in the record's message
-            record.message = self.formatException(exc_info)
-            stack.callback(lambda: setattr(record, "message", full_message))
-            # Apply the same formatting to the traceback
-            traceback_output = self.formatMessage(record)
+        # Pop out the record's exception info so that it doesn't get appended
+        # to the message
+        original_exc_info = record.exc_info
+        record.exc_info = None
+        # Format the message without the exception
+        base_output = super(MemeBotLogFormatter, self).format(record)
+        original_message = record.message
+        # Store the traceback in the record's message
+        record.message = self.formatException(original_exc_info)
+        # Apply the same formatting to the traceback
+        traceback_output = self.formatMessage(record)
+
+        # Reset the record's attributes
+        record.exc_info = original_exc_info
+        record.message = original_message
 
         return f"{base_output}\n{traceback_output}"

--- a/memebot/log/logger.py
+++ b/memebot/log/logger.py
@@ -1,91 +1,32 @@
-import functools
-import inspect
 import io
 import logging
 import os
 import sys
-from typing import Union, Mapping, Optional
 
 from memebot import config
+from memebot.log.filter import MemebotLogFilter
 
 memebot_context = os.getcwd()
-
-
-@functools.lru_cache
-def get_module_name_from_path(path: str) -> str:
-    """
-    Returns the module name for a given file as it would appear in an import statement
-    :param path: The path to the python file
-    :return: Essentially, the output of __name__ if it were referenced in
-    the given module. If the module cannot be found, returns an empty string
-    """
-    target = next(
-        (
-            mod
-            for mod in sys.modules.values()
-            if hasattr(mod, "__file__") and mod.__file__ == path
-        ),
-        None,
-    )
-    return target.__name__ if target else ""
 
 
 class MemeBotLogger(logging.Logger, io.IOBase):
     """
     Defines a logging class that can be used to define a consistent logging style
-    accross all modules
+    across all modules
     """
 
-    def __init__(self, name: str, level: Optional[Union[int, str]] = None):
+    def __init__(self, name: str, level: int | str | None = None):
         super(MemeBotLogger, self).__init__(name, level or config.log_level)
         self.propagate = False
         self.is_interactive = sys.stdin.isatty() or "pydev" in repr(
             __builtins__.get("__import__")  # type: ignore[attr-defined]
         )
+        self.addFilter(MemebotLogFilter())
         super(MemeBotLogger, self).addHandler(config.log_location)
 
     def addHandler(self, _: logging.Handler) -> None:
         # We want to avoid external packages overwriting our custom handler
         return
-
-    def _log(  # type: ignore
-        self,
-        level: int,
-        msg: object,
-        args: tuple[object],
-        exc_info: Optional[BaseException] = None,
-        extra: Union[Mapping[str, object], None] = None,
-        stack_info: bool = False,
-        stacklevel: int = 1,
-    ) -> None:
-        """
-        Apply some hooks to the internal logging function.
-        """
-        try:
-            file_name, line_number, _, _ = self.findCaller(stack_info, stacklevel)
-        except ValueError:
-            # If we can't extract MemeBot logging metadata, just do the best we can
-            super(MemeBotLogger, self)._log(
-                logging.ERROR,
-                "Could not determine log statement callsite.",
-                (),
-                extra={"_callsite": __name__, "_lineno": "logging_error"},
-            )
-            super(MemeBotLogger, self)._log(
-                level, msg, args, exc_info, extra, stack_info, stacklevel
-            )
-            return
-        # Log the line number on which the log statement was made
-        callsite = get_module_name_from_path(file_name)
-        updated_extra = {
-            "_lineno": line_number,
-            "_callsite": callsite if callsite else self.name,
-        }
-        if extra is not None:
-            updated_extra.update(extra)
-        super(MemeBotLogger, self)._log(
-            level, msg, args, exc_info, updated_extra, stack_info, stacklevel
-        )
 
     def write(self, msg: str) -> None:
         """
@@ -98,32 +39,10 @@ class MemeBotLogger(logging.Logger, io.IOBase):
         # can get very wonky
         if self.is_interactive and sys.__stdout__:
             sys.__stdout__.writelines([msg])
-        elif msg and not msg.isspace():
-            # Capture the stack here, on a line without the string "print(" in it
-            stack = inspect.stack()
-            # Find the stack frame which (hopefully) contains the call to print
-            print_frame = next(
-                (
-                    frame
-                    for frame in stack
-                    if "print(" in (frame.code_context or "_")[0]
-                ),
-                None,
-            )
-            if print_frame is not None:
-                module_name = get_module_name_from_path(print_frame.filename)
-                log_extra = {"_callsite": module_name, "_lineno": print_frame.lineno}
-                if print_frame.filename.startswith(memebot_context):
-                    # If someone puts a print statement inside memebot code,
-                    # output it regardless of log level
-                    self.info(msg, extra=log_extra)
-                else:
-                    # Use debug logging for any non-memebot modules using print
-                    self.debug(msg, extra=log_extra)
-            else:
-                self.error(
-                    f"Attempted to format a print statement, "
-                    f"but couldn't figure out where the print came from",
-                    stack_info=True,
-                )
-                self.info(msg)
+            return
+
+        # Ensures a single trailing \n per print call
+        if msg.strip() == "":
+            return
+
+        self.debug(msg, stacklevel=2)


### PR DESCRIPTION
The logger now behaves as desired, relying more on logging internals and stable APIs to resolve the information it requires for formatting.

* Insert fully qualified module path via a new log filter instead of unstable `_log` override
* Remove complicated caller-resolution code
* Allow logging internals to resolve calling code by pushing up the base stack frame in log helpers
* Simplify existing formatting code

Resolves #290
