### PR TITLE
Include embed in `/paywall` command

### DIFF
--- a/memebot/commands/paywall.py
+++ b/memebot/commands/paywall.py
@@ -15,7 +15,7 @@ async def paywall(interaction: discord.Interaction, link: str) -> None:
     link = remove_params(link)
 
     await interaction.response.send_message(
-        f"Link without paywall: https://archive.is/newest/{link}"
+        f"[Link]({link}) without paywall: https://archive.is/newest/{link}"
     )
 
 
@@ -25,7 +25,7 @@ async def paywall_context_menu(
 ) -> None:
     link = remove_params(util.extract_link(message))
     await interaction.response.send_message(
-        f"Link without paywall: https://archive.is/newest/{link}"
+        f"[Link]({link}) without paywall: https://archive.is/newest/{link}"
     )
 
 


### PR DESCRIPTION
Output now includes the original link behind markdown so that the embed still appears when an archive link is posted.

Resolves #296
