### PR TITLE
Switch paywall site to removepaywalls.com

### DIFF
--- a/memebot/commands/paywall.py
+++ b/memebot/commands/paywall.py
@@ -2,6 +2,8 @@ import discord
 
 from memebot.lib import exception, util
 
+PREFIX = "https://removepaywalls.com"
+
 
 @discord.app_commands.command()  # type: ignore
 async def paywall(interaction: discord.Interaction, link: str) -> None:
@@ -15,7 +17,7 @@ async def paywall(interaction: discord.Interaction, link: str) -> None:
     link = remove_params(link)
 
     await interaction.response.send_message(
-        f"Link without paywall: https://archive.is/newest/{link}"
+        f"[Link]({link}) without paywall: {PREFIX}/{link}"
     )
 
 
@@ -25,7 +27,7 @@ async def paywall_context_menu(
 ) -> None:
     link = remove_params(util.extract_link(message))
     await interaction.response.send_message(
-        f"Link without paywall: https://archive.is/newest/{link}"
+        f"[Link]({link}) without paywall: {PREFIX}/{link}"
     )
 
 


### PR DESCRIPTION
We tried to move away from archive.is in 0a1cdf63c5d5df184d3f79a83fd58f0a955adb61 due to poor performance and shady ethics, but archive.org frequently does not work for removing paywalls. That commit was reverted in 717880f650de596fd202004f9416ebb607317556.

removepaywalls.com works and performs well, but it does not embed well in Discord. This patch also re-introduces the feature to include a hyperlink to the original article for the embed.

I've been using this site since archive.is has stopped working and I think it should serve our purposes well.

<img width="985" height="636" alt="image" src="https://github.com/user-attachments/assets/3dc96bf4-6c42-4964-a7b4-8cf97e86b266" />
